### PR TITLE
Design for minimal reservation service

### DIFF
--- a/designs/minimal-reservation-service.md
+++ b/designs/minimal-reservation-service.md
@@ -283,7 +283,7 @@ If no sufficient set of hosts is available, the controller sets a `HostUnavailab
 
 External services that perform per-host programming register a deletion block on the Placement while their programming is active. This prevents the hosts from being released and reclaimed before the programming is reversed.
 
-Per the platform spec (section 5.3), references cross service boundaries via the owning service's reference REST API — external services never write another service's finalizers directly. The reservation service exposes `PUT` and `DELETE` reference endpoints; internally it translates these into finalizer operations on its own CRD. The reference string format follows the canonical `{resource}.{group}/{uuid}` scheme produced by `GenerateResourceReference`.
+Per [platform spec §5.3](../SPECIFICATION.md#53-references), references cross service boundaries via the owning service's reference REST API — external services never write another service's finalizers directly. The reservation service exposes `PUT` and `DELETE` reference endpoints; internally it translates these into finalizer operations on its own CRD. The reference string format follows the canonical `{resource}.{group}/{uuid}` scheme produced by `GenerateResourceReference`.
 
 **Lifecycle:**
 

--- a/designs/minimal-reservation-service.md
+++ b/designs/minimal-reservation-service.md
@@ -48,10 +48,11 @@ type OpenStackReservationStatus struct {
 ```
 
 **Conditions:**
-- `Ready` — set True by the controller once the aggregate is created and hosts are assigned. This is the controller's own health signal, separate from the readiness gates.
-- Gate conditions (e.g. `ib.unikorn-cloud.org/partition-ready`) — set by external services via the REST API. The region service waits for all conditions named in `Spec.ReadinessGates` to be True before using this Reservation as a scheduler hint.
+- `Allocated` — set True by the controller once hosts have been selected and the Nova aggregate created. This is the controller's own signal that the Reservation has been populated.
+- Gate conditions (e.g. `ib.unikorn-cloud.org/partition-ready`) — set by external services via the REST API, as named in `Spec.ReadinessGates`.
+- `Ready` — set True by the controller only when `Allocated` is True and every condition named in `Spec.ReadinessGates` is also True.
 
-A Reservation is usable when both `Ready == True` and all `Spec.ReadinessGates` conditions are True.
+Consumers (e.g. the Server provisioner) wait only for `Ready == True`. They do not inspect individual gate conditions — that aggregation is the controller's responsibility.
 
 ### Controller
 
@@ -70,7 +71,11 @@ On creation (DeletionTimestamp nil):
 3. Record in status
        Status.AggregateID = aggregate UUID
        Status.HostIDs = [ironic node UUID]
-       Set Ready condition True
+       Set Allocated condition True
+
+4. Recompute Ready
+       If Allocated == True and all Spec.ReadinessGates conditions are True:
+           Set Ready condition True
 ```
 
 On deletion (DeletionTimestamp non-nil):
@@ -178,11 +183,10 @@ The region service creates a Reservation when a Network is provisioned in an IB-
 Region service creates Server
 
     1. Fetch Reservation via reservation service REST API
-    2. Check Ready == True (aggregate created, host assigned)
-    3. Check all Spec.ReadinessGates conditions are True
-           If any are False or missing: Server stays pending, requeue
+    2. Check Ready == True
+           If False or absent: Server stays pending, requeue
 
-    4. All gates satisfied:
+    3. Ready == True:
            Read Status.AggregateID from Reservation
            POST /compute/v2/servers with scheduler hint:
                os:scheduler_hints:
@@ -212,6 +216,7 @@ ib-manager subscribes to Reservation lifecycle events via the Kubernetes event b
 6. Program UFM partition (add GUIDs to the `IBPartition`)
 7. `PUT /reservations/{id}/references/{ref}` — register deletion block
 8. `PUT /reservations/{id}/conditions/ib.unikorn-cloud.org/partition-ready` True
+   → reservation service controller requeues, recomputes Ready
 
 **On deletion (DeletionTimestamp non-nil):**
 1. `GET /reservations/{id}` — fetch current state

--- a/designs/minimal-reservation-service.md
+++ b/designs/minimal-reservation-service.md
@@ -395,11 +395,13 @@ Region service creates Server
            If False or absent: Server stays pending, requeue
 
     3. Ready == True:
-           Assign a specific host from Status.HostIDs to this Server
-           (assignment tracked in the Server CRD; each host used at most once)
+           Assign a specific host from Status.HostIDs to this Server:
+               Select a host UUID from Status.HostIDs not already present
+               in Spec.HostID of any existing Server in this Placement.
+               Write the chosen UUID to Spec.HostID on the Server CRD.
            POST /compute/v2/servers with:
                os:scheduler_hints:
-                 force_hosts: [assigned-host-uuid]
+                 force_hosts: [Spec.HostID]
 ```
 
 Each server is targeted at a specific pre-selected host. Nova does not perform host selection — it is directed to the named host. Because all pre-boot programming is complete before any server boots, the host is guaranteed to be in the correct state.

--- a/designs/minimal-reservation-service.md
+++ b/designs/minimal-reservation-service.md
@@ -2,34 +2,182 @@
 
 ## Overview
 
-The reservation service pre-allocates bare metal hosts for a VPC before any server is booted. It is OpenStack-specific: it talks to Nova and Ironic, and its internal CRDs model OpenStack concepts directly.
+The reservation service pre-allocates bare metal hosts before any server is booted. The design here is OpenStack-specific: it talks to Nova and Ironic, and its internal CRDs model OpenStack concepts directly.
 
-**The problem it solves.** Bare metal host selection by Nova placement is opportunistic — at `nova boot` time, placement picks whatever host satisfies the flavour constraints. For workloads that need pre-boot infrastructure programming (IB partition assignment, network programming, topology-aware placement), the host must be known and programmed before the boot call. The reservation service pins the host early and holds it, allowing dependent services to complete their programming against a stable host identity before any instance runs.
+**The problem it solves.**
 
-**What the reservation service does.** The operative concept in the minimal design is the *Placement*. A caller creates a Placement specifying a region, a flavour, a VPC, and a set of readiness gates. The controller selects available hosts of the right flavour, creates a Nova host aggregate containing those hosts, and records the aggregate ID and selected host list in status. External services (e.g. ib-manager) receive a Placement creation event, perform their per-host programming, and signal readiness by setting a named condition on the Placement via the reservation service REST API. Once all gates are satisfied and the Placement is marked Ready, callers can create Servers: the region service reads the aggregate ID from the Placement and passes it to Nova as a scheduler hint, constraining placement to the pre-programmed hosts.
+Bare metal host selection by Nova placement is opportunistic — at `nova boot` time, placement picks whatever host satisfies the flavour constraints. For workloads that need pre-boot infrastructure programming (IB partition assignment, network programming, topology-aware placement), the host must be known and programmed before the boot call. The reservation service pins the hosts early and holds them, allowing dependent services to complete their programming against a stable host identity before any instance runs.
 
-**Scope.** This design covers the minimal case: one host per Placement. Multi-host Placements with topology constraints, and Reservations as a capacity management layer above Placements, are planned expansions but not designed here.
+In addition, we want primitives for placing a set of hosts for a cluster, so they have optimal connectivity or resilience.
+
+**What the reservation service does.**
+
+The design uses two abstractions with separate concerns.
+
+A *Reservation* is a capacity boundary at the NVLink domain level (for simplicity, with some loss of accuracy: "rack"). It claims a set of racks exclusively for a project or purpose, preventing those racks from being used by any other Reservation.
+
+A *Placement* is an allocation carved from a Reservation. At allocation time, the controller selects a specific set of hosts from the Reservation's racks, applying spread constraints to control how those hosts are distributed. It refers to a VPC and is represented in OpenStack as a Nova host aggregate. The host list is fixed once the Placement is confirmed.
+
+Server creation is then unconditional fill: the topology work is done at Placement creation. The region service reads the aggregate ID from the Placement and passes it to Nova as a scheduler hint; no host selection or spread logic runs at server boot time. Any additional preparation (e.g., IB partition assignment) is already programmed before the first server boots.
+
+**Scope.** This design covers the two-level model (Reservation + Placement), multi-host Placements with topology spread constraints, and the gate-based readiness protocol used to support additional host preparation.
 
 ---
 
 ## Design
+
+### Physical Hierarchy
+
+```
+Site
+  └── POD (a.k.a., scaling unit; everything connected within one hop)
+        └── Rack or NVLink domain (e.g., for GB300 NVL72 deployments, it's the whole rack; for a B200 deployment it coincides with hosts)
+              └── Machine (one compute tray)
+```
+
+For a site, these are fixed and homogeneous — every POD contains the same number of racks, every rack the same number of machines. Capacity at any level is derivable by multiplication.
+
+For GB300, the minimum Reservation granularity is **one full rack**: the NVLink domain boundary means a single GB300 compute tray triggers reservation of the entire rack.
+
+### CRD: `OpenStackReservation`
+
+The `OpenStackReservation` CRD is internal to the reservation service. It represents a capacity boundary at rack granularity; it contains no host list, no VPC, and no IB partition.
+
+```go
+type OpenStackReservationRequestTopology struct {
+    // Hierarchy level to reserve at (e.g. "rack").
+    Level string
+    // Number of units at that level.
+    Count int
+}
+
+type OpenStackReservationRequestResources struct {
+    GPUCount int
+    GPUModel string
+}
+
+type OpenStackReservationRequest struct {
+    // Style is "topology-first" or "resource-first".
+    Style string
+    // Topology is set when Style is "topology-first".
+    Topology *OpenStackReservationRequestTopology
+    // Resources is set when Style is "resource-first".
+    Resources *OpenStackReservationRequestResources
+    // FailurePolicy controls behaviour when exact satisfaction is impossible.
+    // "hard" rejects; "soft" allocates as much as possible.
+    FailurePolicy string
+}
+
+type OpenStackReservationLocalityPreference struct {
+    // Level is the hierarchy level to prefer locality within (e.g. "scale_unit").
+    Level string
+    // FailurePolicy controls behaviour if locality cannot be achieved.
+    FailurePolicy string
+}
+
+type OpenStackReservationSpec struct {
+    // Region in which to reserve capacity.
+    RegionID string
+    // Request describes how much capacity to claim and at what level.
+    Request OpenStackReservationRequest
+    // LocalityPreference optionally constrains rack selection to minimise
+    // the number of scale units spanned.
+    LocalityPreference *OpenStackReservationLocalityPreference
+    // NotBefore is a schema stub; no automated transitions yet.
+    NotBefore *metav1.Time
+    // ExpiresAt is a schema stub; no automated transitions yet.
+    ExpiresAt *metav1.Time
+    // ParentReservationID is a schema stub for nested reservations.
+    ParentReservationID string
+}
+
+type OpenStackReservationStatus struct {
+    // RackIDs is the confirmed set of Ironic node UUIDs for the reserved racks.
+    // Set atomically at creation; immutable thereafter.
+    RackIDs []string
+    // LocalityLevel is the highest hierarchy level at which locality was achieved.
+    LocalityLevel string
+    // State is "Active" or "Deleting".
+    State string
+}
+```
+
+### Reservation Controller
+
+On creation (DeletionTimestamp nil):
+
+```
+1. Validate the request against the hierarchy configuration.
+   For resource-first: compute minimum rack count to satisfy the resource
+   request, then proceed as topology-first.
+
+2. Query racks with sufficient healthy machines not already covered
+   by any active Reservation.
+
+3. Apply locality preference: prefer racks within the fewest scale units.
+   If failure_policy is "hard" and a single scale unit cannot supply
+   the requested count, reject with a clean error.
+
+4. Conflict-check: no rack in the candidate set appears in any existing
+   active Reservation.
+
+5. Atomically write Status.RackIDs, Status.LocalityLevel, Status.State = Active.
+   Add controller finalizer.
+```
+
+On deletion (DeletionTimestamp non-nil):
+
+```
+1. If any Placement with this ReservationID still exists: requeue.
+
+2. Clear Status.RackIDs, set Status.State = Deleting.
+
+3. Remove controller finalizer — Reservation is deleted.
+```
 
 ### CRD: `OpenStackPlacement`
 
 The `OpenStackPlacement` CRD is internal to the reservation service. Its schema uses OpenStack terminology directly — there is no provider abstraction.
 
 ```go
+type PlacementSpreadConstraint struct {
+    // Level is the hierarchy level to spread across (e.g. "rack").
+    Level string
+    // MaxSkew is the maximum permitted difference in host count between
+    // any two nodes at this level. 0 means as even as possible.
+    MaxSkew int
+    // FailurePolicy controls behaviour when the constraint cannot be satisfied.
+    // "hard" rejects; "soft" records the actual skew and proceeds.
+    FailurePolicy string
+}
+
+type PlacementSpreadResult struct {
+    Level         string
+    RequestedSkew int
+    ActualSkew    int
+    Satisfied     bool
+}
+
 type OpenStackPlacementSpec struct {
-    // Region in which to allocate a host
+    // Region in which to allocate hosts.
     RegionID string
-    // VPC (Network) this Placement is associated with.
-    // External services (e.g. ib-manager) use this to determine which
-    // partition or network resource to program for the placed hosts.
+    // ReservationID is the Reservation from which hosts are drawn.
+    // Host selection is constrained to the Reservation's RackIDs.
+    ReservationID string
+    // MachineCount is the number of hosts required.
+    MachineCount int
+    // SpreadConstraints controls how MachineCount hosts are distributed
+    // across topology levels within the Reservation's racks.
+    SpreadConstraints []PlacementSpreadConstraint
+    // NetworkID (VPC) this Placement is associated with.
+    // Gate services use this to determine which network resource to program
+    // for the placed hosts.
     NetworkID string
-    // Flavour determining which class of host to select
+    // FlavorID determines which class of host to select.
     FlavorID string
-    // Condition types that must be True before this Placement is usable.
-    // Copied verbatim from Region.Spec.ReadinessGates at creation time.
+    // ReadinessGates lists condition types that must be True before this
+    // Placement is usable. Copied verbatim from Region.Spec.ReadinessGates
+    // at creation time.
     ReadinessGates []string
 }
 
@@ -39,10 +187,12 @@ type OpenStackPlacementStatus struct {
     // are ineligible for selection by any other Placement.
     AggregateID string
     // Ironic node UUIDs of the hosts assigned to this Placement.
-    // Set by the controller after host selection; immutable thereafter.
-    // Read by external services (e.g. ib-manager) to discover which
-    // hosts to program.
+    // Set atomically at creation; immutable thereafter.
+    // Read by gate services to discover which hosts to program.
     HostIDs []string
+    // SpreadResults records per-constraint outcomes: actual skew achieved
+    // and whether the failure policy was honoured.
+    SpreadResults []PlacementSpreadResult
     // Standard Kubernetes conditions.
     // Includes the controller-owned Ready condition and any gate conditions
     // set by external services.
@@ -59,7 +209,7 @@ Consumers (e.g. the Server provisioner) wait only for `Ready == True`. They do n
 
 **Immutability.** `Status.HostIDs` does not change after it is first set. This is required so that the readiness gate fires exactly once and the programmed state of external services (e.g. the UFM partition) remains stable.
 
-### Controller
+### Placement Controller
 
 On creation (DeletionTimestamp nil):
 
@@ -74,6 +224,7 @@ On creation (DeletionTimestamp nil):
 3. Record in status
        Status.AggregateID = aggregate UUID
        Status.HostIDs = [ironic node UUIDs]
+       Status.SpreadResults = [per-constraint outcomes]
        Set Allocated condition True
 
 4. Recompute Ready
@@ -98,7 +249,10 @@ The controller adds its own finalizer on creation to ensure the deletion path ru
 
 ### Host Selection
 
-The controller queries the OpenStack Placement API to find available hosts, then filters for hosts not already committed to another Placement.
+The controller loads the parent Reservation to constrain the candidate set, then queries the OpenStack Placement API, then applies spread constraints.
+
+**Step 0 — Load the parent Reservation.**
+Verify `Status.State == Active`. Collect `Status.RackIDs`. All subsequent candidate enumeration is restricted to hosts whose rack membership is within this set.
 
 **Step 1 — Resolve the resource class from the flavour.**
 The flavour's extra specs contain `resources:CUSTOM_BAREMETAL_LARGE=1` (or equivalent). The controller queries Nova for the flavour and reads the `resources:CUSTOM_*` key to obtain the resource class name.
@@ -109,7 +263,7 @@ The flavour's extra specs contain `resources:CUSTOM_BAREMETAL_LARGE=1` (or equiv
 GET /placement/resource_providers?resources=CUSTOM_BAREMETAL_LARGE:1
 ```
 
-This returns only resource providers with free capacity. This is the correct source of truth because a node mid-deploy is already marked consumed in Placement even though its Ironic provision state is still `deploying`.
+This returns only resource providers with free capacity. This is the correct source of truth because a node mid-deploy is already marked consumed in Placement even though its Ironic provision state is still `deploying`. The result is filtered to hosts whose rack membership is within the Reservation's `RackIDs`.
 
 **Step 3 — Filter by aggregate membership.**
 Each candidate is checked against Nova: any host already a member of an existing Placement aggregate is excluded. This is the disjointness mechanism — it ensures a host cannot be assigned to more than one Placement without requiring cross-CRD scanning.
@@ -119,9 +273,10 @@ Placement has a ~60-second sync lag from Ironic. To guard against stale data, ea
 - `provision_state == available`
 - `maintenance == false`
 
-A host passing all checks is selected.
+**Step 5 — Apply spread constraints.**
+Group the remaining candidates by rack. For each constraint in `Spec.SpreadConstraints`, distribute `MachineCount` hosts to satisfy `MaxSkew`. If `FailurePolicy: hard` and the constraint cannot be satisfied with available hosts, reject and return an error. Record actual skew per constraint in `SpreadResults`.
 
-If no host is available, the controller sets a `HostUnavailable` condition and requeues. Host selection is best-effort with no distributed lock — in the event of a race between two concurrent Placements selecting the same host, the aggregate-membership check reduces but does not eliminate the window. The minimal service accepts this: single-host Placements with human-driven scheduling make races rare in practice.
+If no sufficient set of hosts is available, the controller sets a `HostUnavailable` condition and requeues. Host selection is best-effort with no distributed lock — in the event of a race between two concurrent Placements selecting the same host, the aggregate-membership check reduces but does not eliminate the window.
 
 ### Resource References
 
@@ -132,14 +287,14 @@ Per the platform spec (section 5.3), references cross service boundaries via the
 **Lifecycle:**
 
 ```
-ib-manager programs IB partition
+Gate service performs per-host programming
     → PUT .../placements/{id}/references/{ref}
     → reservation service adds finalizer to Placement CRD
 
 Placement deleted (DeletionTimestamp set)
     → controller sees inbound reference via GetResourceReferences(), requeues
 
-ib-manager receives deletion event, reverses UFM programming
+Gate service receives deletion event, reverses programming
     → DELETE .../placements/{id}/references/{ref}
     → reservation service removes finalizer from Placement CRD
 
@@ -155,9 +310,9 @@ Full end-to-end deletion sequence:
 User deletes Placement
     │ DeletionTimestamp set
     ▼
-Event bus fires → external services receive deletion notification
-    ib-manager:
-        Removes host GUIDs from UFM partition
+Event bus fires → gate services receive deletion notification
+    gate service:
+        Reverses per-host programming
         DELETE .../placements/{id}/references/{ref}
 
 Placement controller (requeued):
@@ -166,22 +321,34 @@ Placement controller (requeued):
         No  → DELETE Nova aggregate
               Remove controller finalizer
               Placement removed from etcd
+
+All Placements from Reservation deleted
+    │
+    ▼
+User deletes Reservation
+    → Reservation controller releases RackIDs, removes finalizer
 ```
 
 ---
 
 ## REST API
 
-All endpoints are called by external services (region service, ib-manager). The reservation service writes to its own CRDs in response; callers never touch CRDs directly.
+All endpoints are called by external services (region service, gate services). The reservation service writes to its own CRDs in response; callers never touch CRDs directly.
 
 | Method | Path | Caller | Purpose |
 |---|---|---|---|
+| `GET` | `/topology` | Region service | Hierarchy config and resource profile per machine |
+| `GET` | `/topology/nodes` | Region service | All nodes at a given level with available count |
+| `POST` | `/reservations` | Region service / operator | Create a Reservation |
+| `GET` | `/reservations` | Region service | List active Reservations for the project |
+| `GET` | `/reservations/{id}` | Region service | Read Reservation state and rack IDs |
+| `DELETE` | `/reservations/{id}` | Region service / operator | Delete a Reservation |
 | `POST` | `/placements` | Region service | Create a Placement |
-| `GET` | `/placements/{id}` | Region service, ib-manager | Read full Placement state (host list, aggregate ID, conditions) |
+| `GET` | `/placements/{id}` | Region service, gate services | Read full Placement state (host list, aggregate ID, conditions) |
 | `DELETE` | `/placements/{id}` | Region service | Delete a Placement |
-| `PUT` | `/placements/{id}/conditions/{type}` | ib-manager | Set a named condition (e.g. `ib.unikorn-cloud.org/partition-ready: True`) |
-| `PUT` | `/placements/{id}/references/{name}` | ib-manager | Register a deletion block (idempotent) |
-| `DELETE` | `/placements/{id}/references/{name}` | ib-manager | Release a deletion block (idempotent) |
+| `PUT` | `/placements/{id}/conditions/{type}` | Gate service | Set a named condition |
+| `PUT` | `/placements/{id}/references/{name}` | Gate service | Register a deletion block (idempotent) |
+| `DELETE` | `/placements/{id}/references/{name}` | Gate service | Release a deletion block (idempotent) |
 
 All calls use mTLS; the caller's service account certificate is its identity.
 
@@ -189,10 +356,29 @@ All calls use mTLS; the caller's service account certificate is its identity.
 
 ## Integration with the Region Service
 
+### Creating a Reservation
+
+The region service (or operator tooling) creates a Reservation to claim a set of racks for a project. Example for a 2-rack dev slice with soft scale-unit locality:
+
+```json
+POST /reservations
+{
+  "request": {
+    "style": "topology-first",
+    "topology": { "level": "rack", "count": 2 },
+    "failure_policy": "hard"
+  },
+  "locality_preference": { "level": "scale_unit", "failure_policy": "soft" }
+}
+```
+
 ### Creating a Placement
 
-The region service creates a Placement when a Network is provisioned in an IB-capable region (or more generally, whenever the Region's `Spec.ReadinessGates` is non-empty). The Placement is created with:
+The region service creates a Placement when a Network is provisioned in an IB-capable region. The Placement is created with:
 - `RegionID` from the Network's region
+- `ReservationID` of the Reservation covering this project's racks
+- `MachineCount` from the intended cluster size
+- `SpreadConstraints` from the cluster topology policy
 - `NetworkID` from the Network being provisioned
 - `FlavorID` from the intended Server flavour
 - `ReadinessGates` copied verbatim from `Region.Spec.ReadinessGates`
@@ -215,39 +401,33 @@ Region service creates Server
            (Aggregate metadata key set by reservation service at aggregate creation time)
 ```
 
-Nova placement selects the single host within the aggregate. Because only one host is in the aggregate and all pre-boot programming is complete, placement is deterministic.
-
-### Placement-to-Server relationship
-
-In the minimal service, one Placement is consumed by at most one Server. The region service is responsible for enforcing this: once a Server has been booted against a Placement, the Placement is considered consumed and should not be reused.
+Nova selects any available host within the aggregate. Because all pre-boot programming is complete and the IB partition covers the full host set, placement is deterministic. Concurrent server creation calls against the same Placement are safe — Nova handles contention within the aggregate.
 
 ---
 
-## Integration with ib-manager
+## Integration with Gate Services
 
-ib-manager subscribes to Placement lifecycle events via the Kubernetes event bus (informer on the `OpenStackPlacement` CRD). The envelope carries `ResourceID` and `DeletionTimestamp`.
+A gate service subscribes to Placement lifecycle events via the Kubernetes event bus (informer on the `OpenStackPlacement` CRD). The envelope carries `ResourceID` and `DeletionTimestamp`.
 
 **On creation (DeletionTimestamp nil):**
 1. `GET /placements/{id}` — fetch full state including `Spec.NetworkID` and `Status.HostIDs`
-2. Fetch flavour via region service REST API → `FlavorInfiniBandSpec.PortCount`
-3. If `PortCount == 0`: set `ib.unikorn-cloud.org/partition-ready` True — done
-4. Look up the `IBPartition` for `Spec.NetworkID`
-5. For each host in `Status.HostIDs`, query Ironic for IB port GUIDs
-6. Program UFM partition (add GUIDs to the `IBPartition`)
-7. `PUT /placements/{id}/references/{ref}` — register deletion block
-8. `PUT /placements/{id}/conditions/ib.unikorn-cloud.org/partition-ready` True
+2. Determine whether this Placement requires programming by this gate service (e.g. check flavour capabilities).
+3. If not applicable: set the gate condition True and return.
+4. Perform per-host programming using `Spec.NetworkID` and `Status.HostIDs` as inputs.
+5. `PUT /placements/{id}/references/{ref}` — register deletion block
+6. `PUT /placements/{id}/conditions/{gate-condition}` True
    → reservation service controller requeues, recomputes Ready
 
 **On deletion (DeletionTimestamp non-nil):**
 1. `GET /placements/{id}` — fetch current state
-2. Remove host GUIDs from UFM partition
+2. Reverse per-host programming
 3. `DELETE /placements/{id}/references/{ref}` — release deletion block
 
 ---
 
 ## Event Bus
 
-The reservation service publishes Placement lifecycle events to the Kubernetes event bus using the same envelope pattern as the region service: `ResourceID` and `DeletionTimestamp`. Subscribers (ib-manager) wire up a Kubernetes informer on the `OpenStackPlacement` CRD type.
+The reservation service publishes Placement lifecycle events to the Kubernetes event bus using the same envelope pattern as the region service: `ResourceID` and `DeletionTimestamp`. Gate services wire up a Kubernetes informer on the `OpenStackPlacement` CRD type.
 
 `DeletionTimestamp == nil` → creation or update event.
 `DeletionTimestamp` non-nil → deletion in progress; subscriber should reverse its programming.
@@ -256,13 +436,17 @@ The reservation service publishes Placement lifecycle events to the Kubernetes e
 
 ## Future Expansion
 
-The minimal design is deliberately constrained to one host per Placement and no topology constraints. The intended expansion path:
+**Pre-booking (R3).** Activate `NotBefore` / `ExpiresAt` transitions on the Reservation. Add time-window overlap to conflict detection. No schema changes needed.
 
-**Multi-host Placements.** Add `Spec.Count int` (defaulting to 1) to support multi-host Placements. `Status.HostIDs` is already a slice — no schema change needed. Host selection generalises from "pick one" to "pick N satisfying the topology constraint."
+**Ranked fallback (R4).** A retry loop around the Reservation satisfaction algorithm, relaxing the rack count by one per iteration.
 
-**Topology constraints.** Add a `Spec.Topology` field describing the placement policy: rack affinity (contiguous racks, hard-fail if unavailable), rack spread (anti-affinity with max-skew per rack, soft or hard), and similar. Topology is evaluated at host selection time within the Placement controller. The aggregate membership disjointness check runs first; the topology filter runs over the remaining candidates. This covers use cases P1 (rack-contiguous production) and P2 (cross-rack dev spread) from the use-case set.
+**Spot capacity.** Introduce a pool of machines not covered by any active Reservation. Spot Placements draw from this pool with no exclusivity guarantee.
 
-**Reservations as a capacity management layer.** An `OpenStackReservation` CRD can be added above Placements to provide advance capacity booking and multi-Placement capacity management. A Reservation claims N units of a given flavour (possibly time-bound) and the Placement draws from that reserved pool rather than the open pool. This enables use cases R3 (future-dated bookings) and R4 (ranked fallback) and allows a policy decision about whether unreserved Placements are permitted. In the minimal design this layer is absent and all capacity is first-come first-served.
+**Nested Reservations.** Activate `ParentReservationID`. Enforce that child `RackIDs` ⊆ parent `RackIDs`.
+
+**Topology labels on instances.** Hierarchy position labels fall directly out of `HostIDs` and the hierarchy model. Can be added to the server provisioner independently.
+
+**Multiple Placements per Reservation.** Already supported by the model — a Reservation's `RackIDs` can be parcelled into multiple non-overlapping Placements. Conflict detection at the host level prevents overlap automatically.
 
 ---
 
@@ -270,13 +454,14 @@ The minimal design is deliberately constrained to one host per Placement and no 
 
 | Date | Decision | Rationale |
 |---|---|---|
-| 2026-04-01 | `Spec.NetworkID` carried on Placement | External services (e.g. ib-manager) need the VPC association to know which partition or network resource to program. Carrying it in Spec avoids a separate lookup and makes the Placement self-describing. |
+| 2026-04-01 | `Spec.NetworkID` carried on Placement | Gate services need the VPC association to know which network resource to program. Carrying it in Spec avoids a separate lookup and makes the Placement self-describing. |
 | 2026-04-01 | Deletion blocking via reference REST API, not direct finalizer writes | Per platform spec section 5.3, external services never write another service's finalizers directly. The reservation service exposes canonical `PUT`/`DELETE` reference endpoints and manages finalizers internally. |
 | 2026-04-01 | CRD named `OpenStackPlacement` | The CRD is OpenStack-specific (Nova aggregates, Ironic node UUIDs). Making the provider explicit in the type name is consistent with the design's stated principle of no provider abstraction, and avoids naming conflicts if other provider types are added later. |
 | 2026-04-01 | Host selection via Placement API, cross-checked against Ironic | `GET /placement/resource_providers?resources=<class>:1` gives a more accurate availability view than querying Ironic directly — it reflects Nova allocations for nodes mid-deploy. Resource class is resolved from the flavour's `resources:CUSTOM_*` extra spec. Ironic is still checked to guard against Placement's ~60s sync lag. |
 | 2026-04-08 | Disjointness enforced via Nova aggregate membership | A host already in any Placement aggregate is excluded from selection by a new Placement. This uses Nova's own state as the source of truth rather than scanning CRDs, and provides the same guarantee with less coordination. |
-| 2026-04-08 | Topology constraints are a Placement concern, not a Reservation concern | Topology is a placement policy — where to put hosts — not a capacity policy. Rack affinity and spread are placement use cases. The Reservation layer (when added) expresses count and time bounds; the Placement expresses topology. |
-| 2026-04-08 | Minimal design uses Placements only; Reservations deferred | IB partitioning requires only a stable host list, a VPC binding, and readiness gates — all of which are Placement properties. The Reservation layer adds capacity management and advance booking, which are not needed for the minimal IB case. Deferring it removes one CRD and one controller from the minimal implementation. |
+| 2026-04-08 | Topology constraints are a Placement concern, not a Reservation concern | Topology is a placement policy — where to put hosts — not a capacity policy. Rack affinity and spread are placement use cases. The Reservation layer expresses count and locality; the Placement expresses spread and host selection. |
+| 2026-04-09 | Reservation is a rack-level capacity boundary; Placement carves hosts from it | Separates the operator concern (which racks are dedicated to this project) from the workload concern (how to distribute N hosts across those racks). Gate services' contract is unchanged — they still see only a Placement with a fixed host list, a VPC, and readiness gates. |
+| 2026-04-09 | Server creation is unconditional aggregate fill | Spread constraints fire once at Placement creation. At server boot time there is no host selection and no spread logic — Nova picks any available host within the aggregate. This keeps the server provisioner simple and makes concurrent server creation safe. |
 
 ---
 
@@ -290,11 +475,11 @@ The current system boots servers directly via Nova with no pre-placement, no Pla
 
 ### New IB-capable regions — opt-in by operator
 
-A region with an IB fabric is configured with `ib.unikorn-cloud.org/partition-ready` in `Region.Spec.ReadinessGates` at deploy time. Only these regions use Placements and gate-based pre-boot coordination. Enabling ib-manager for a region is a single operator change to the Region definition; no flavour updates or server changes are needed.
+A region with an IB fabric is configured with `ib.unikorn-cloud.org/partition-ready` in `Region.Spec.ReadinessGates` at deploy time. Only these regions use Placements and gate-based pre-boot coordination. Enabling a gate service for a region is a single operator change to the Region definition; no flavour updates or server changes are needed.
 
 ### Existing servers — no backfill
 
-Servers already running have no associated Placement. They do not need one: IB partitions for running servers were never programmed (there was no ib-manager), and retrofitting a Placement to a running server would not change the hardware state. The Server provisioner must handle both cases:
+Servers already running have no associated Placement. They do not need one: per-host programming for running servers was never performed (there were no gate services), and retrofitting a Placement to a running server would not change the hardware state. The Server provisioner must handle both cases:
 
 - **No Placement reference on the Server:** use the existing direct Nova placement path (current behaviour, unchanged).
 - **Placement reference present:** check all gates, then boot with the aggregate scheduler hint.
@@ -308,6 +493,7 @@ All CRD changes introduced by this design are additive optional fields:
 | Resource | New field | Default | Impact on existing resources |
 |---|---|---|---|
 | `Region` | `Spec.ReadinessGates []string` | `[]` (empty) | None — existing Regions have no gates |
+| `OpenStackReservation` | Entire new CRD | — | None — no existing Reservations |
 | `OpenStackPlacement` | Entire new CRD | — | None — no existing Placements |
 | `Flavor` | `Spec.InfiniBand.PortCount int` | `0` | None — existing Flavours have zero IB ports |
 
@@ -317,8 +503,8 @@ No data migration is required. Existing resources are valid under the new schema
 
 1. Deploy the updated region service with `Region.Spec.ReadinessGates` support and the conditional Server provisioner path.
 2. Deploy the reservation service (or activate it within `uni-region` depending on the placement decision).
-3. Deploy ib-manager.
-4. For each IB-capable region, add `ib.unikorn-cloud.org/partition-ready` to `Region.Spec.ReadinessGates`.
+3. Deploy gate services.
+4. For each region requiring gate-based pre-boot coordination, add the relevant gate condition names to `Region.Spec.ReadinessGates`.
 
 Steps 1–3 have no user-visible effect. Step 4 activates the new path for that region only.
 
@@ -330,7 +516,7 @@ Two deployment options exist. The choice has not yet been made.
 
 ### Option A: Embedded in the Region Service
 
-The Placement controller and handler live inside `uni-region`. The `OpenStackPlacement` CRD belongs to the region service API group.
+The Placement and Reservation controllers and handlers live inside `uni-region`. The `OpenStackPlacement` and `OpenStackReservation` CRDs belong to the region service API group.
 
 **Advantages:**
 - Host selection can use internal region service state directly — flavour-to-resource-class mapping, Ironic client, and existing host inventory are all in-process. No new endpoints needed.
@@ -338,8 +524,8 @@ The Placement controller and handler live inside `uni-region`. The `OpenStackPla
 - The Placement is a natural extension of region concepts (flavours, hosts, aggregates).
 
 **Disadvantages:**
-- The region service grows larger. Placement lifecycle (host selection, aggregate management, gate coordination) is a distinct concern from network and identity management.
-- All consumers (ib-manager, future gate services) already call the region service; adding placement endpoints there conflates two separate responsibilities.
+- The region service grows larger. Placement and Reservation lifecycle is a distinct concern from network and identity management.
+- All consumers (gate services) already call the region service; adding placement endpoints there conflates two separate responsibilities.
 
 ### Option B: Separate Service (`uni-reservation`)
 
@@ -348,7 +534,7 @@ The reservation service is a standalone binary with its own CRDs, API, and deplo
 **Advantages:**
 - Clean separation of concerns. The reservation service owns host pre-allocation; the region service owns networks and identities.
 - Independently deployable and scalable.
-- The service boundary makes the gate protocol explicit — ib-manager calls `uni-reservation`, not `uni-region`.
+- The service boundary makes the gate protocol explicit — gate services call `uni-reservation`, not `uni-region`.
 
 **Disadvantages:**
 - Host selection requires knowing which Ironic nodes are available for a given flavour. This state currently lives in the region service. A separate service would need either:
@@ -370,4 +556,6 @@ The reservation service is a standalone binary with its own CRDs, API, and deplo
 
 5. **Service placement:** Should the reservation service be embedded in `uni-region` (Option A) or deployed as a separate service `uni-reservation` (Option B)? See the Service Placement section. The deciding factor is likely host selection: if a "list available hosts for flavour" endpoint can be added to the region service, Option B becomes more viable. If not, Option A avoids duplicating Ironic and flavour-mapping logic.
 
-6. **Rack membership data source for topology-aware host selection:** When topology constraints are added to Placements, the host selection algorithm must group candidate hosts by rack. The OpenStack Placement API returns individual resource providers (Ironic node UUIDs) with no rack grouping. A source of rack membership per node is needed — e.g. Ironic node traits, nested resource providers in Placement, or an operator-maintained topology map. This needs to be confirmed against the target deployment before topology-aware selection can be designed.
+6. **Rack membership data source (blocking):** The Reservation creation algorithm requires grouping candidate hosts by rack. The OpenStack Placement API returns individual resource providers (Ironic node UUIDs) with no rack grouping. A source of rack membership per node must be confirmed before the Reservation controller can be implemented — candidates: Ironic node traits, nested resource providers in OpenStack Placement, or an operator-maintained topology ConfigMap.
+
+7. **Unreserved Placements:** The two-level model makes `ReservationID` a required field on a Placement. The previous design allowed Placements against the open pool. Should unreserved Placements remain permitted as a fallback, or is a Reservation now always required?

--- a/designs/minimal-reservation-service.md
+++ b/designs/minimal-reservation-service.md
@@ -540,4 +540,4 @@ The reservation service is a standalone binary with its own CRDs, API, and deplo
 
 6. **Rack membership data source (blocking):** The Reservation creation algorithm requires grouping candidate hosts by rack. The OpenStack Placement API returns individual resource providers (Ironic node UUIDs) with no rack grouping. A source of rack membership per node must be confirmed before the Reservation controller can be implemented — candidates: Ironic node traits, nested resource providers in OpenStack Placement, or an operator-maintained topology ConfigMap.
 
-7. **Unreserved Placements:** The two-level model makes `ReservationID` a required field on a Placement. The previous design allowed Placements against the open pool. Should unreserved Placements remain permitted as a fallback, or is a Reservation now always required?
+7. **Unreserved Placements:** The two-level model makes `ReservationID` a required field on a Placement (`OpenStackPlacementSpec.ReservationID string`). The previous design allowed Placements against the open pool. Should unreserved Placements remain permitted as a fallback (making `ReservationID` optional), or is a Reservation now always required?

--- a/designs/minimal-reservation-service.md
+++ b/designs/minimal-reservation-service.md
@@ -84,12 +84,6 @@ type OpenStackReservationSpec struct {
     // LocalityPreference optionally constrains rack selection to minimise
     // the number of scale units spanned.
     LocalityPreference *OpenStackReservationLocalityPreference
-    // NotBefore is a schema stub; no automated transitions yet.
-    NotBefore *metav1.Time
-    // ExpiresAt is a schema stub; no automated transitions yet.
-    ExpiresAt *metav1.Time
-    // ParentReservationID is a schema stub for nested reservations.
-    ParentReservationID string
 }
 
 type OpenStackReservationStatus struct {

--- a/designs/minimal-reservation-service.md
+++ b/designs/minimal-reservation-service.md
@@ -6,39 +6,42 @@ The reservation service pre-allocates bare metal hosts for a VPC before any serv
 
 **The problem it solves.** Bare metal host selection by Nova placement is opportunistic — at `nova boot` time, placement picks whatever host satisfies the flavour constraints. For workloads that need pre-boot infrastructure programming (IB partition assignment, network programming, topology-aware placement), the host must be known and programmed before the boot call. The reservation service pins the host early and holds it, allowing dependent services to complete their programming against a stable host identity before any instance runs.
 
-**What the reservation service does.** A caller creates a Reservation specifying a region, a flavour, and a set of readiness gates. The controller selects an available host of the right flavour, creates a Nova host aggregate containing that host, and records the aggregate ID in status. External services (e.g. ib-manager) receive a notification, perform their per-host programming, and signal readiness by setting a named condition on the Reservation via the reservation service REST API. Once all gates are satisfied and the Reservation is marked Ready, a caller can create a Server against it: the region service reads the aggregate ID from the Reservation and passes it to Nova as a scheduler hint, constraining placement to the pre-programmed host.
+**What the reservation service does.** The operative concept in the minimal design is the *Placement*. A caller creates a Placement specifying a region, a flavour, a VPC, and a set of readiness gates. The controller selects available hosts of the right flavour, creates a Nova host aggregate containing those hosts, and records the aggregate ID and selected host list in status. External services (e.g. ib-manager) receive a Placement creation event, perform their per-host programming, and signal readiness by setting a named condition on the Placement via the reservation service REST API. Once all gates are satisfied and the Placement is marked Ready, callers can create Servers: the region service reads the aggregate ID from the Placement and passes it to Nova as a scheduler hint, constraining placement to the pre-programmed hosts.
 
-**Scope.** This design covers the minimal case: one host per Reservation. Multi-host reservations (e.g. a full rack) are a planned expansion but not designed here.
+**Scope.** This design covers the minimal case: one host per Placement. Multi-host Placements with topology constraints, and Reservations as a capacity management layer above Placements, are planned expansions but not designed here.
 
 ---
 
 ## Design
 
-### CRD: `OpenStackReservation`
+### CRD: `OpenStackPlacement`
 
-The `OpenStackReservation` CRD is internal to the reservation service. Its schema uses OpenStack terminology directly — there is no provider abstraction.
+The `OpenStackPlacement` CRD is internal to the reservation service. Its schema uses OpenStack terminology directly — there is no provider abstraction.
 
 ```go
-type OpenStackReservationSpec struct {
+type OpenStackPlacementSpec struct {
     // Region in which to allocate a host
     RegionID string
-    // VPC (Network) this Reservation is associated with.
+    // VPC (Network) this Placement is associated with.
     // External services (e.g. ib-manager) use this to determine which
-    // partition or network resource to program for the reserved host.
+    // partition or network resource to program for the placed hosts.
     NetworkID string
     // Flavour determining which class of host to select
     FlavorID string
-    // Condition types that must be True before this Reservation is usable.
+    // Condition types that must be True before this Placement is usable.
     // Copied verbatim from Region.Spec.ReadinessGates at creation time.
     ReadinessGates []string
 }
 
-type OpenStackReservationStatus struct {
-    // Nova host aggregate UUID created for this Reservation
+type OpenStackPlacementStatus struct {
+    // Nova host aggregate UUID created for this Placement.
+    // Also serves as the disjointness signal: hosts in this aggregate
+    // are ineligible for selection by any other Placement.
     AggregateID string
-    // Ironic node UUIDs of the hosts assigned to this Reservation.
-    // Set by the controller after host selection; read by external services
-    // (e.g. ib-manager) to discover which hosts to program.
+    // Ironic node UUIDs of the hosts assigned to this Placement.
+    // Set by the controller after host selection; immutable thereafter.
+    // Read by external services (e.g. ib-manager) to discover which
+    // hosts to program.
     HostIDs []string
     // Standard Kubernetes conditions.
     // Includes the controller-owned Ready condition and any gate conditions
@@ -48,29 +51,29 @@ type OpenStackReservationStatus struct {
 ```
 
 **Conditions:**
-- `Allocated` — set True by the controller once hosts have been selected and the Nova aggregate created. This is the controller's own signal that the Reservation has been populated.
+- `Allocated` — set True by the controller once hosts have been selected, added to the aggregate, and recorded in `Status.HostIDs`. This is the controller's own signal that the Placement has been populated.
 - Gate conditions (e.g. `ib.unikorn-cloud.org/partition-ready`) — set by external services via the REST API, as named in `Spec.ReadinessGates`.
 - `Ready` — set True by the controller only when `Allocated` is True and every condition named in `Spec.ReadinessGates` is also True.
 
 Consumers (e.g. the Server provisioner) wait only for `Ready == True`. They do not inspect individual gate conditions — that aggregation is the controller's responsibility.
+
+**Immutability.** `Status.HostIDs` does not change after it is first set. This is required so that the readiness gate fires exactly once and the programmed state of external services (e.g. the UFM partition) remains stable.
 
 ### Controller
 
 On creation (DeletionTimestamp nil):
 
 ```
-1. Select an available host
-       Query Ironic for nodes with a resource class matching FlavorID
-       Filter out nodes already referenced in another active Reservation
-       Pick one node
+1. Select available hosts
+       See Host Selection below
 
 2. Create Nova host aggregate
        POST /compute/v2/os-aggregates
-       Add the selected host to the aggregate
+       Add the selected hosts to the aggregate
 
 3. Record in status
        Status.AggregateID = aggregate UUID
-       Status.HostIDs = [ironic node UUID]
+       Status.HostIDs = [ironic node UUIDs]
        Set Allocated condition True
 
 4. Recompute Ready
@@ -88,17 +91,17 @@ On deletion (DeletionTimestamp non-nil):
 2. Delete Nova host aggregate
        DELETE /compute/v2/os-aggregates/{id}
 
-3. Remove controller finalizer — Reservation is deleted
+3. Remove controller finalizer — Placement is deleted
 ```
 
 The controller adds its own finalizer on creation to ensure the deletion path runs before the object is removed from etcd.
 
 ### Host Selection
 
-The controller queries the OpenStack Placement API to find available hosts. Each Ironic node is a resource provider in Placement, with its UUID matching the Ironic node UUID. A bare metal node exposes one unit of a single custom resource class derived from its `resource_class` field (e.g. `baremetal-large` → `CUSTOM_BAREMETAL_LARGE`).
+The controller queries the OpenStack Placement API to find available hosts, then filters for hosts not already committed to another Placement.
 
 **Step 1 — Resolve the resource class from the flavour.**
-The flavour's extra specs contain `resources:CUSTOM_BAREMETAL_LARGE=1` (or equivalent). The controller queries Nova for the flavour and reads the `resources:CUSTOM_*` key to obtain the resource class name. No separate mapping is needed.
+The flavour's extra specs contain `resources:CUSTOM_BAREMETAL_LARGE=1` (or equivalent). The controller queries Nova for the flavour and reads the `resources:CUSTOM_*` key to obtain the resource class name.
 
 **Step 2 — Query Placement for available hosts.**
 
@@ -106,22 +109,23 @@ The flavour's extra specs contain `resources:CUSTOM_BAREMETAL_LARGE=1` (or equiv
 GET /placement/resource_providers?resources=CUSTOM_BAREMETAL_LARGE:1
 ```
 
-This returns only resource providers with free capacity — i.e. nodes registered in Placement with no existing allocation. This is the correct source of truth because:
-- A node being deployed by Nova is already marked consumed in Placement, even though its Ironic provision state is still `deploying`. Querying Ironic alone would incorrectly consider it available.
-- Placement's inventory is authoritative for Nova scheduling; using it for host selection aligns the reservation service's view with the scheduler's view.
+This returns only resource providers with free capacity. This is the correct source of truth because a node mid-deploy is already marked consumed in Placement even though its Ironic provision state is still `deploying`.
 
-**Step 3 — Cross-check against Ironic.**
-Placement has a ~60-second sync lag from Ironic. To guard against stale data, each candidate returned by Placement is checked directly against Ironic:
+**Step 3 — Filter by aggregate membership.**
+Each candidate is checked against Nova: any host already a member of an existing Placement aggregate is excluded. This is the disjointness mechanism — it ensures a host cannot be assigned to more than one Placement without requiring cross-CRD scanning.
+
+**Step 4 — Cross-check against Ironic.**
+Placement has a ~60-second sync lag from Ironic. To guard against stale data, each remaining candidate is checked directly against Ironic:
 - `provision_state == available`
 - `maintenance == false`
 
-A host passing both checks is selected.
+A host passing all checks is selected.
 
-If no host is available, the controller sets an `HostUnavailable` condition and requeues. Host selection is best-effort with no distributed lock — in the event of a race between two concurrent Reservations selecting the same host, the aggregate creation for one will succeed and ib-manager will catch the conflict on the other when it attempts to programme the same GUIDs. The minimal service accepts this: single-host reservations with human-driven scheduling make races rare in practice.
+If no host is available, the controller sets a `HostUnavailable` condition and requeues. Host selection is best-effort with no distributed lock — in the event of a race between two concurrent Placements selecting the same host, the aggregate-membership check reduces but does not eliminate the window. The minimal service accepts this: single-host Placements with human-driven scheduling make races rare in practice.
 
 ### Resource References
 
-External services that perform per-host programming register a deletion block on the Reservation while their programming is active. This prevents the aggregate from being torn down before the programming is reversed.
+External services that perform per-host programming register a deletion block on the Placement while their programming is active. This prevents the aggregate from being torn down before the programming is reversed.
 
 Per the platform spec (section 5.3), references cross service boundaries via the owning service's reference REST API — external services never write another service's finalizers directly. The reservation service exposes `PUT` and `DELETE` reference endpoints; internally it translates these into finalizer operations on its own CRD. The reference string format follows the canonical `{resource}.{group}/{uuid}` scheme produced by `GenerateResourceReference`.
 
@@ -129,15 +133,15 @@ Per the platform spec (section 5.3), references cross service boundaries via the
 
 ```
 ib-manager programs IB partition
-    → PUT .../reservations/{id}/references/{ref}
-    → reservation service adds finalizer to Reservation CRD
+    → PUT .../placements/{id}/references/{ref}
+    → reservation service adds finalizer to Placement CRD
 
-Reservation deleted (DeletionTimestamp set)
+Placement deleted (DeletionTimestamp set)
     → controller sees inbound reference via GetResourceReferences(), requeues
 
 ib-manager receives deletion event, reverses UFM programming
-    → DELETE .../reservations/{id}/references/{ref}
-    → reservation service removes finalizer from Reservation CRD
+    → DELETE .../placements/{id}/references/{ref}
+    → reservation service removes finalizer from Placement CRD
 
 No references remain
     → controller proceeds: deletes aggregate, removes its own finalizer
@@ -148,20 +152,20 @@ No references remain
 Full end-to-end deletion sequence:
 
 ```
-User deletes Reservation
+User deletes Placement
     │ DeletionTimestamp set
     ▼
 Event bus fires → external services receive deletion notification
     ib-manager:
         Removes host GUIDs from UFM partition
-        DELETE .../reservations/{id}/references/{ref}
+        DELETE .../placements/{id}/references/{ref}
 
-Reservation controller (requeued):
+Placement controller (requeued):
     GetResourceReferences() non-empty?
         Yes → requeue
         No  → DELETE Nova aggregate
               Remove controller finalizer
-              Reservation removed from etcd
+              Placement removed from etcd
 ```
 
 ---
@@ -172,12 +176,12 @@ All endpoints are called by external services (region service, ib-manager). The 
 
 | Method | Path | Caller | Purpose |
 |---|---|---|---|
-| `POST` | `/reservations` | Region service | Create a Reservation |
-| `GET` | `/reservations/{id}` | Region service, ib-manager | Read full Reservation state (host list, aggregate ID, conditions) |
-| `DELETE` | `/reservations/{id}` | Region service | Delete a Reservation |
-| `PUT` | `/reservations/{id}/conditions/{type}` | ib-manager | Set a named condition (e.g. `ib.unikorn-cloud.org/partition-ready: True`) |
-| `PUT` | `/reservations/{id}/references/{name}` | ib-manager | Register a deletion block (idempotent) |
-| `DELETE` | `/reservations/{id}/references/{name}` | ib-manager | Release a deletion block (idempotent) |
+| `POST` | `/placements` | Region service | Create a Placement |
+| `GET` | `/placements/{id}` | Region service, ib-manager | Read full Placement state (host list, aggregate ID, conditions) |
+| `DELETE` | `/placements/{id}` | Region service | Delete a Placement |
+| `PUT` | `/placements/{id}/conditions/{type}` | ib-manager | Set a named condition (e.g. `ib.unikorn-cloud.org/partition-ready: True`) |
+| `PUT` | `/placements/{id}/references/{name}` | ib-manager | Register a deletion block (idempotent) |
+| `DELETE` | `/placements/{id}/references/{name}` | ib-manager | Release a deletion block (idempotent) |
 
 All calls use mTLS; the caller's service account certificate is its identity.
 
@@ -185,9 +189,9 @@ All calls use mTLS; the caller's service account certificate is its identity.
 
 ## Integration with the Region Service
 
-### Creating a Reservation
+### Creating a Placement
 
-The region service creates a Reservation when a Network is provisioned in an IB-capable region (or more generally, whenever the Region's `Spec.ReadinessGates` is non-empty). The Reservation is created with:
+The region service creates a Placement when a Network is provisioned in an IB-capable region (or more generally, whenever the Region's `Spec.ReadinessGates` is non-empty). The Placement is created with:
 - `RegionID` from the Network's region
 - `NetworkID` from the Network being provisioned
 - `FlavorID` from the intended Server flavour
@@ -198,52 +202,52 @@ The region service creates a Reservation when a Network is provisioned in an IB-
 ```
 Region service creates Server
 
-    1. Fetch Reservation via reservation service REST API
+    1. Fetch Placement via reservation service REST API
     2. Check Ready == True
            If False or absent: Server stays pending, requeue
 
     3. Ready == True:
-           Read Status.AggregateID from Reservation
+           Read Status.AggregateID from Placement
            POST /compute/v2/servers with scheduler hint:
                os:scheduler_hints:
                  aggregate_instance_extra_specs:
-                   unikorn-reservation: {reservation-id}
+                   unikorn-placement: {placement-id}
            (Aggregate metadata key set by reservation service at aggregate creation time)
 ```
 
 Nova placement selects the single host within the aggregate. Because only one host is in the aggregate and all pre-boot programming is complete, placement is deterministic.
 
-### Server-to-Reservation relationship
+### Placement-to-Server relationship
 
-In the minimal service, one Reservation is consumed by at most one Server. The region service is responsible for enforcing this: once a Server has been booted against a Reservation, the Reservation is considered consumed and should not be reused.
+In the minimal service, one Placement is consumed by at most one Server. The region service is responsible for enforcing this: once a Server has been booted against a Placement, the Placement is considered consumed and should not be reused.
 
 ---
 
 ## Integration with ib-manager
 
-ib-manager subscribes to Reservation lifecycle events via the Kubernetes event bus (informer on the Reservation CRD). The envelope carries `ResourceID` and `DeletionTimestamp`.
+ib-manager subscribes to Placement lifecycle events via the Kubernetes event bus (informer on the `OpenStackPlacement` CRD). The envelope carries `ResourceID` and `DeletionTimestamp`.
 
 **On creation (DeletionTimestamp nil):**
-1. `GET /reservations/{id}` — fetch full state including `Spec.NetworkID` and `Status.HostIDs`
+1. `GET /placements/{id}` — fetch full state including `Spec.NetworkID` and `Status.HostIDs`
 2. Fetch flavour via region service REST API → `FlavorInfiniBandSpec.PortCount`
 3. If `PortCount == 0`: set `ib.unikorn-cloud.org/partition-ready` True — done
 4. Look up the `IBPartition` for `Spec.NetworkID`
 5. For each host in `Status.HostIDs`, query Ironic for IB port GUIDs
 6. Program UFM partition (add GUIDs to the `IBPartition`)
-7. `PUT /reservations/{id}/references/{ref}` — register deletion block
-8. `PUT /reservations/{id}/conditions/ib.unikorn-cloud.org/partition-ready` True
+7. `PUT /placements/{id}/references/{ref}` — register deletion block
+8. `PUT /placements/{id}/conditions/ib.unikorn-cloud.org/partition-ready` True
    → reservation service controller requeues, recomputes Ready
 
 **On deletion (DeletionTimestamp non-nil):**
-1. `GET /reservations/{id}` — fetch current state
+1. `GET /placements/{id}` — fetch current state
 2. Remove host GUIDs from UFM partition
-3. `DELETE /reservations/{id}/references/{ref}` — release deletion block
+3. `DELETE /placements/{id}/references/{ref}` — release deletion block
 
 ---
 
 ## Event Bus
 
-The reservation service publishes Reservation lifecycle events to the Kubernetes event bus using the same envelope pattern as the region service: `ResourceID` and `DeletionTimestamp`. Subscribers (ib-manager) wire up a Kubernetes informer on the Reservation CRD type.
+The reservation service publishes Placement lifecycle events to the Kubernetes event bus using the same envelope pattern as the region service: `ResourceID` and `DeletionTimestamp`. Subscribers (ib-manager) wire up a Kubernetes informer on the `OpenStackPlacement` CRD type.
 
 `DeletionTimestamp == nil` → creation or update event.
 `DeletionTimestamp` non-nil → deletion in progress; subscriber should reverse its programming.
@@ -252,13 +256,13 @@ The reservation service publishes Reservation lifecycle events to the Kubernetes
 
 ## Future Expansion
 
-The minimal design is deliberately constrained to one host per Reservation. The intended expansion path:
+The minimal design is deliberately constrained to one host per Placement and no topology constraints. The intended expansion path:
 
-- Add `Spec.Count int` (defaulting to 1) to support multi-host reservations
-- `Status.HostIDs` already a slice — no schema change needed for the multi-host case
-- Host selection logic generalises from "pick one" to "pick N"
-- Resource reference and gate mechanisms are unchanged
-- Further expansion to rack-level reservations would add a `Spec.Topology` field describing the grouping constraint (e.g. all hosts on the same top-of-rack switch)
+**Multi-host Placements.** Add `Spec.Count int` (defaulting to 1) to support multi-host Placements. `Status.HostIDs` is already a slice — no schema change needed. Host selection generalises from "pick one" to "pick N satisfying the topology constraint."
+
+**Topology constraints.** Add a `Spec.Topology` field describing the placement policy: rack affinity (contiguous racks, hard-fail if unavailable), rack spread (anti-affinity with max-skew per rack, soft or hard), and similar. Topology is evaluated at host selection time within the Placement controller. The aggregate membership disjointness check runs first; the topology filter runs over the remaining candidates. This covers use cases P1 (rack-contiguous production) and P2 (cross-rack dev spread) from the use-case set.
+
+**Reservations as a capacity management layer.** An `OpenStackReservation` CRD can be added above Placements to provide advance capacity booking and multi-Placement capacity management. A Reservation claims N units of a given flavour (possibly time-bound) and the Placement draws from that reserved pool rather than the open pool. This enables use cases R3 (future-dated bookings) and R4 (ranked fallback) and allows a policy decision about whether unreserved Placements are permitted. In the minimal design this layer is absent and all capacity is first-come first-served.
 
 ---
 
@@ -266,31 +270,34 @@ The minimal design is deliberately constrained to one host per Reservation. The 
 
 | Date | Decision | Rationale |
 |---|---|---|
-| 2026-04-01 | `Spec.NetworkID` carried on Reservation | External services (e.g. ib-manager) need the VPC association to know which partition or network resource to program. Carrying it in Spec avoids a separate lookup and makes the Reservation self-describing. |
+| 2026-04-01 | `Spec.NetworkID` carried on Placement | External services (e.g. ib-manager) need the VPC association to know which partition or network resource to program. Carrying it in Spec avoids a separate lookup and makes the Placement self-describing. |
 | 2026-04-01 | Deletion blocking via reference REST API, not direct finalizer writes | Per platform spec section 5.3, external services never write another service's finalizers directly. The reservation service exposes canonical `PUT`/`DELETE` reference endpoints and manages finalizers internally. |
-| 2026-04-01 | CRD named `OpenStackReservation` | The CRD is OpenStack-specific (Nova aggregates, Ironic node UUIDs). Making the provider explicit in the type name is consistent with the design's stated principle of no provider abstraction, and avoids naming conflicts if other provider types are added later. |
+| 2026-04-01 | CRD named `OpenStackPlacement` | The CRD is OpenStack-specific (Nova aggregates, Ironic node UUIDs). Making the provider explicit in the type name is consistent with the design's stated principle of no provider abstraction, and avoids naming conflicts if other provider types are added later. |
 | 2026-04-01 | Host selection via Placement API, cross-checked against Ironic | `GET /placement/resource_providers?resources=<class>:1` gives a more accurate availability view than querying Ironic directly — it reflects Nova allocations for nodes mid-deploy. Resource class is resolved from the flavour's `resources:CUSTOM_*` extra spec. Ironic is still checked to guard against Placement's ~60s sync lag. |
+| 2026-04-08 | Disjointness enforced via Nova aggregate membership | A host already in any Placement aggregate is excluded from selection by a new Placement. This uses Nova's own state as the source of truth rather than scanning CRDs, and provides the same guarantee with less coordination. |
+| 2026-04-08 | Topology constraints are a Placement concern, not a Reservation concern | Topology is a placement policy — where to put hosts — not a capacity policy. Rack affinity and spread are placement use cases. The Reservation layer (when added) expresses count and time bounds; the Placement expresses topology. |
+| 2026-04-08 | Minimal design uses Placements only; Reservations deferred | IB partitioning requires only a stable host list, a VPC binding, and readiness gates — all of which are Placement properties. The Reservation layer adds capacity management and advance booking, which are not needed for the minimal IB case. Deferring it removes one CRD and one controller from the minimal implementation. |
 
 ---
 
 ## Migration
 
-The current system boots servers directly via Nova with no pre-placement, no Reservations, and no readiness gates. The migration must be non-breaking for existing regions and existing servers.
+The current system boots servers directly via Nova with no pre-placement, no Placements, and no readiness gates. The migration must be non-breaking for existing regions and existing servers.
 
 ### Existing regions — no change required
 
-`Region.Spec.ReadinessGates` is a new optional field that defaults to empty. An empty gate list means no gates are required before a Reservation is used as a scheduler hint — and with no Reservation in the boot path at all, existing regions behave exactly as before. No operator action is needed for regions that do not have an IB fabric.
+`Region.Spec.ReadinessGates` is a new optional field that defaults to empty. An empty gate list means no gates are required before a Placement is used as a scheduler hint — and with no Placement in the boot path at all, existing regions behave exactly as before. No operator action is needed for regions that do not have an IB fabric.
 
 ### New IB-capable regions — opt-in by operator
 
-A region with an IB fabric is configured with `ib.unikorn-cloud.org/partition-ready` in `Region.Spec.ReadinessGates` at deploy time. Only these regions use Reservations and gate-based pre-boot coordination. Enabling ib-manager for a region is a single operator change to the Region definition; no flavour updates or server changes are needed.
+A region with an IB fabric is configured with `ib.unikorn-cloud.org/partition-ready` in `Region.Spec.ReadinessGates` at deploy time. Only these regions use Placements and gate-based pre-boot coordination. Enabling ib-manager for a region is a single operator change to the Region definition; no flavour updates or server changes are needed.
 
 ### Existing servers — no backfill
 
-Servers already running have no associated Reservation. They do not need one: IB partitions for running servers were never programmed (there was no ib-manager), and retrofitting a Reservation to a running server would not change the hardware state. The Server provisioner must handle both cases:
+Servers already running have no associated Placement. They do not need one: IB partitions for running servers were never programmed (there was no ib-manager), and retrofitting a Placement to a running server would not change the hardware state. The Server provisioner must handle both cases:
 
-- **No Reservation reference on the Server:** use the existing direct Nova placement path (current behaviour, unchanged).
-- **Reservation reference present:** check all gates, then boot with the aggregate scheduler hint.
+- **No Placement reference on the Server:** use the existing direct Nova placement path (current behaviour, unchanged).
+- **Placement reference present:** check all gates, then boot with the aggregate scheduler hint.
 
 This conditional is the only place in the codebase where the old and new paths diverge. Existing servers continue to work without modification.
 
@@ -301,7 +308,7 @@ All CRD changes introduced by this design are additive optional fields:
 | Resource | New field | Default | Impact on existing resources |
 |---|---|---|---|
 | `Region` | `Spec.ReadinessGates []string` | `[]` (empty) | None — existing Regions have no gates |
-| `Reservation` | Entire new CRD | — | None — no existing Reservations |
+| `OpenStackPlacement` | Entire new CRD | — | None — no existing Placements |
 | `Flavor` | `Spec.InfiniBand.PortCount int` | `0` | None — existing Flavours have zero IB ports |
 
 No data migration is required. Existing resources are valid under the new schema without modification.
@@ -323,16 +330,16 @@ Two deployment options exist. The choice has not yet been made.
 
 ### Option A: Embedded in the Region Service
 
-The reservation controller and handler live inside `uni-region`. The `Reservation` CRD belongs to the region service API group.
+The Placement controller and handler live inside `uni-region`. The `OpenStackPlacement` CRD belongs to the region service API group.
 
 **Advantages:**
 - Host selection can use internal region service state directly — flavour-to-resource-class mapping, Ironic client, and existing host inventory are all in-process. No new endpoints needed.
 - One less service to deploy and operate.
-- The Reservation is a natural extension of region concepts (flavours, hosts, aggregates).
+- The Placement is a natural extension of region concepts (flavours, hosts, aggregates).
 
 **Disadvantages:**
-- The region service grows larger. Reservation lifecycle (host selection, aggregate management, gate coordination) is a distinct concern from network and identity management.
-- All consumers (ib-manager, future gate services) already call the region service; adding reservation endpoints there conflates two separate responsibilities.
+- The region service grows larger. Placement lifecycle (host selection, aggregate management, gate coordination) is a distinct concern from network and identity management.
+- All consumers (ib-manager, future gate services) already call the region service; adding placement endpoints there conflates two separate responsibilities.
 
 ### Option B: Separate Service (`uni-reservation`)
 
@@ -353,12 +360,14 @@ The reservation service is a standalone binary with its own CRDs, API, and deplo
 
 ## Open Questions
 
-1. **Host selection race:** The minimal service accepts a best-effort selection with no distributed lock. Is this acceptable for the target deployment, or does the host pool turn over fast enough that races are a real concern?
+1. **Host selection race:** The minimal service accepts a best-effort selection with no distributed lock. The aggregate-membership filter reduces the race window but does not eliminate it: two concurrent Placements can both pass the filter before either has created its aggregate. Is this acceptable for the target deployment?
 
-2. **Aggregate scheduler hint mechanism:** The design uses `aggregate_instance_extra_specs` with a `unikorn-reservation` metadata key on the aggregate, requiring `AggregateInstanceExtraSpecsFilter` in Nova's scheduler filter list. This needs to be confirmed as enabled in the target deployment.
+2. **Aggregate scheduler hint mechanism:** The design uses `aggregate_instance_extra_specs` with a `unikorn-placement` metadata key on the aggregate, requiring `AggregateInstanceExtraSpecsFilter` in Nova's scheduler filter list. This needs to be confirmed as enabled in the target deployment.
 
 3. ~~**Flavour-to-resource-class mapping:**~~ Resolved — the resource class is read directly from the flavour's `resources:CUSTOM_*` extra spec. No separate mapping needed.
 
-4. **Reservation ownership:** Who owns the lifecycle of a Reservation — is it created and deleted by the region service on behalf of a user, or is it a user-visible resource? For the minimal service, treating it as an internal implementation detail of the region service (not directly user-facing) is simplest.
+4. **Placement ownership:** Who owns the lifecycle of a Placement — is it created and deleted by the region service on behalf of a user, or is it a user-visible resource? For the minimal service, treating it as an internal implementation detail of the region service (not directly user-facing) is simplest.
 
 5. **Service placement:** Should the reservation service be embedded in `uni-region` (Option A) or deployed as a separate service `uni-reservation` (Option B)? See the Service Placement section. The deciding factor is likely host selection: if a "list available hosts for flavour" endpoint can be added to the region service, Option B becomes more viable. If not, Option A avoids duplicating Ironic and flavour-mapping logic.
+
+6. **Rack membership data source for topology-aware host selection:** When topology constraints are added to Placements, the host selection algorithm must group candidate hosts by rack. The OpenStack Placement API returns individual resource providers (Ironic node UUIDs) with no rack grouping. A source of rack membership per node is needed — e.g. Ironic node traits, nested resource providers in Placement, or an operator-maintained topology map. This needs to be confirmed against the target deployment before topology-aware selection can be designed.

--- a/designs/minimal-reservation-service.md
+++ b/designs/minimal-reservation-service.md
@@ -195,6 +195,7 @@ type OpenStackPlacementStatus struct {
 
 **Conditions:**
 - `Allocated` — set True by the controller once hosts have been selected, claimed, and recorded in `Status.HostIDs`. This is the controller's own signal that the Placement has been populated.
+- `HostUnavailable` — set True by the controller when no sufficient set of hosts can be found to satisfy the Placement request. The controller requeues; once hosts become available the condition is cleared and allocation proceeds.
 - Gate conditions (e.g. `ib.unikorn-cloud.org/partition-ready`) — set by external services via the REST API, as named in `Spec.ReadinessGates`.
 - `Ready` — set True by the controller only when `Allocated` is True and every condition named in `Spec.ReadinessGates` is also True.
 

--- a/designs/minimal-reservation-service.md
+++ b/designs/minimal-reservation-service.md
@@ -306,24 +306,9 @@ No references remain
 
 ### Deletion Protocol
 
-Full end-to-end deletion sequence:
+Once all Placements under a Reservation are deleted:
 
 ```
-User deletes Placement
-    │ DeletionTimestamp set
-    ▼
-Event bus fires → gate services receive deletion notification
-    gate service:
-        Reverses per-host programming
-        DELETE .../placements/{id}/references/{ref}
-
-Placement controller (requeued):
-    GetResourceReferences() non-empty?
-        Yes → requeue
-        No  → Remove CUSTOM_UNIKORN_CLAIMED trait from each host
-              Remove controller finalizer
-              Placement removed from etcd
-
 All Placements from Reservation deleted
     │
     ▼

--- a/designs/minimal-reservation-service.md
+++ b/designs/minimal-reservation-service.md
@@ -95,13 +95,29 @@ The controller adds its own finalizer on creation to ensure the deletion path ru
 
 ### Host Selection
 
-A host is considered available if:
-- Its Ironic provision state is `available`
-- It is not in maintenance
-- Its resource class matches the requested flavour
-- Its Ironic node UUID does not appear in `Status.HostIDs` of any other active (non-deleting) Reservation in the same region
+The controller queries the OpenStack Placement API to find available hosts. Each Ironic node is a resource provider in Placement, with its UUID matching the Ironic node UUID. A bare metal node exposes one unit of a single custom resource class derived from its `resource_class` field (e.g. `baremetal-large` → `CUSTOM_BAREMETAL_LARGE`).
 
-Host selection is best-effort at creation time. If no host is available, the controller sets a condition (`HostUnavailable`) and requeues. It does not hold a lock between selection and aggregate creation — in the unlikely event of a race, the duplicate will be caught when the second reservation attempts to programme the same host (e.g. ib-manager will error on a conflicting GUID). The minimal service accepts this: single-host reservations with human-driven scheduling make races rare in practice.
+**Step 1 — Resolve the resource class from the flavour.**
+The flavour's extra specs contain `resources:CUSTOM_BAREMETAL_LARGE=1` (or equivalent). The controller queries Nova for the flavour and reads the `resources:CUSTOM_*` key to obtain the resource class name. No separate mapping is needed.
+
+**Step 2 — Query Placement for available hosts.**
+
+```
+GET /placement/resource_providers?resources=CUSTOM_BAREMETAL_LARGE:1
+```
+
+This returns only resource providers with free capacity — i.e. nodes registered in Placement with no existing allocation. This is the correct source of truth because:
+- A node being deployed by Nova is already marked consumed in Placement, even though its Ironic provision state is still `deploying`. Querying Ironic alone would incorrectly consider it available.
+- Placement's inventory is authoritative for Nova scheduling; using it for host selection aligns the reservation service's view with the scheduler's view.
+
+**Step 3 — Cross-check against Ironic.**
+Placement has a ~60-second sync lag from Ironic. To guard against stale data, each candidate returned by Placement is checked directly against Ironic:
+- `provision_state == available`
+- `maintenance == false`
+
+A host passing both checks is selected.
+
+If no host is available, the controller sets an `HostUnavailable` condition and requeues. Host selection is best-effort with no distributed lock — in the event of a race between two concurrent Reservations selecting the same host, the aggregate creation for one will succeed and ib-manager will catch the conflict on the other when it attempts to programme the same GUIDs. The minimal service accepts this: single-host reservations with human-driven scheduling make races rare in practice.
 
 ### Resource References
 
@@ -253,6 +269,7 @@ The minimal design is deliberately constrained to one host per Reservation. The 
 | 2026-04-01 | `Spec.NetworkID` carried on Reservation | External services (e.g. ib-manager) need the VPC association to know which partition or network resource to program. Carrying it in Spec avoids a separate lookup and makes the Reservation self-describing. |
 | 2026-04-01 | Deletion blocking via reference REST API, not direct finalizer writes | Per platform spec section 5.3, external services never write another service's finalizers directly. The reservation service exposes canonical `PUT`/`DELETE` reference endpoints and manages finalizers internally. |
 | 2026-04-01 | CRD named `OpenStackReservation` | The CRD is OpenStack-specific (Nova aggregates, Ironic node UUIDs). Making the provider explicit in the type name is consistent with the design's stated principle of no provider abstraction, and avoids naming conflicts if other provider types are added later. |
+| 2026-04-01 | Host selection via Placement API, cross-checked against Ironic | `GET /placement/resource_providers?resources=<class>:1` gives a more accurate availability view than querying Ironic directly — it reflects Nova allocations for nodes mid-deploy. Resource class is resolved from the flavour's `resources:CUSTOM_*` extra spec. Ironic is still checked to guard against Placement's ~60s sync lag. |
 
 ---
 
@@ -340,7 +357,7 @@ The reservation service is a standalone binary with its own CRDs, API, and deplo
 
 2. **Aggregate scheduler hint mechanism:** The design uses `aggregate_instance_extra_specs` with a `unikorn-reservation` metadata key on the aggregate, requiring `AggregateInstanceExtraSpecsFilter` in Nova's scheduler filter list. This needs to be confirmed as enabled in the target deployment.
 
-3. **Flavour-to-resource-class mapping:** Host selection requires mapping `FlavorID` to an Ironic resource class. The mechanism for this lookup (via region service, directly from Nova, or via a local cache) is not yet specified.
+3. ~~**Flavour-to-resource-class mapping:**~~ Resolved — the resource class is read directly from the flavour's `resources:CUSTOM_*` extra spec. No separate mapping needed.
 
 4. **Reservation ownership:** Who owns the lifecycle of a Reservation — is it created and deleted by the region service on behalf of a user, or is it a user-visible resource? For the minimal service, treating it as an internal implementation detail of the region service (not directly user-facing) is simplest.
 

--- a/designs/minimal-reservation-service.md
+++ b/designs/minimal-reservation-service.md
@@ -40,9 +40,6 @@ type ReservationStatus struct {
     // Set by the controller after host selection; read by external services
     // (e.g. ib-manager) to discover which hosts to program.
     HostIDs []string
-    // Services that have registered a deletion block on this Reservation.
-    // The Reservation cannot be deleted while this list is non-empty.
-    ResourceReferences []string
     // Standard Kubernetes conditions.
     // Includes the controller-owned Ready condition and any gate conditions
     // set by external services.
@@ -79,15 +76,17 @@ On creation (DeletionTimestamp nil):
 On deletion (DeletionTimestamp non-nil):
 
 ```
-1. If Status.ResourceReferences is non-empty: requeue, do not proceed
+1. If GetResourceReferences() is non-empty: requeue, do not proceed
+   (inbound references signal that a dependent service has not yet
+   reversed its programming)
 
 2. Delete Nova host aggregate
        DELETE /compute/v2/os-aggregates/{id}
 
-3. Remove finalizer — Reservation is deleted
+3. Remove controller finalizer — Reservation is deleted
 ```
 
-The controller adds a finalizer on creation to ensure the deletion path runs before the object is removed from etcd.
+The controller adds its own finalizer on creation to ensure the deletion path runs before the object is removed from etcd.
 
 ### Host Selection
 
@@ -103,24 +102,24 @@ Host selection is best-effort at creation time. If no host is available, the con
 
 External services that perform per-host programming register a deletion block on the Reservation while their programming is active. This prevents the aggregate from being torn down before the programming is reversed.
 
-The mechanism is a named entry in `Status.ResourceReferences`. The reservation service owns all writes to its own CRDs; external services add and remove references via the REST API.
+Per the platform spec (section 5.3), references cross service boundaries via the owning service's reference REST API — external services never write another service's finalizers directly. The reservation service exposes `PUT` and `DELETE` reference endpoints; internally it translates these into finalizer operations on its own CRD. The reference string format follows the canonical `{resource}.{group}/{uuid}` scheme produced by `GenerateResourceReference`.
 
 **Lifecycle:**
 
 ```
 ib-manager programs IB partition
-    → POST .../reservations/{id}/references  body: {"name": "ib-manager"}
-    → reservation service appends "ib-manager" to Status.ResourceReferences
+    → PUT .../reservations/{id}/references/{ref}
+    → reservation service adds finalizer to Reservation CRD
 
 Reservation deleted (DeletionTimestamp set)
-    → controller sees ResourceReferences non-empty, blocks
+    → controller sees inbound reference via GetResourceReferences(), requeues
 
 ib-manager receives deletion event, reverses UFM programming
-    → DELETE .../reservations/{id}/references/ib-manager
-    → reservation service removes "ib-manager" from Status.ResourceReferences
+    → DELETE .../reservations/{id}/references/{ref}
+    → reservation service removes finalizer from Reservation CRD
 
-ResourceReferences now empty
-    → controller proceeds: deletes aggregate, removes finalizer
+No references remain
+    → controller proceeds: deletes aggregate, removes its own finalizer
 ```
 
 ### Deletion Protocol
@@ -134,13 +133,13 @@ User deletes Reservation
 Event bus fires → external services receive deletion notification
     ib-manager:
         Removes host GUIDs from UFM partition
-        DELETE .../reservations/{id}/references/ib-manager
+        DELETE .../reservations/{id}/references/{ref}
 
 Reservation controller (requeued):
-    ResourceReferences empty?
-        No  → requeue
-        Yes → DELETE Nova aggregate
-              Remove finalizer
+    GetResourceReferences() non-empty?
+        Yes → requeue
+        No  → DELETE Nova aggregate
+              Remove controller finalizer
               Reservation removed from etcd
 ```
 
@@ -156,8 +155,8 @@ All endpoints are called by external services (region service, ib-manager). The 
 | `GET` | `/reservations/{id}` | Region service, ib-manager | Read full Reservation state (host list, aggregate ID, conditions) |
 | `DELETE` | `/reservations/{id}` | Region service | Delete a Reservation |
 | `PUT` | `/reservations/{id}/conditions/{type}` | ib-manager | Set a named condition (e.g. `ib.unikorn-cloud.org/partition-ready: True`) |
-| `POST` | `/reservations/{id}/references` | ib-manager | Register a deletion block |
-| `DELETE` | `/reservations/{id}/references/{name}` | ib-manager | Release a deletion block |
+| `PUT` | `/reservations/{id}/references/{name}` | ib-manager | Register a deletion block (idempotent) |
+| `DELETE` | `/reservations/{id}/references/{name}` | ib-manager | Release a deletion block (idempotent) |
 
 All calls use mTLS; the caller's service account certificate is its identity.
 
@@ -211,13 +210,13 @@ ib-manager subscribes to Reservation lifecycle events via the Kubernetes event b
 4. Look up the `IBPartition` for `Spec.NetworkID`
 5. For each host in `Status.HostIDs`, query Ironic for IB port GUIDs
 6. Program UFM partition (add GUIDs to the `IBPartition`)
-7. Register deletion block on the Reservation
-8. Set `ib.unikorn-cloud.org/partition-ready` True on the Reservation
+7. `PUT /reservations/{id}/references/{ref}` — register deletion block
+8. `PUT /reservations/{id}/conditions/ib.unikorn-cloud.org/partition-ready` True
 
 **On deletion (DeletionTimestamp non-nil):**
 1. `GET /reservations/{id}` — fetch current state
 2. Remove host GUIDs from UFM partition
-3. `DELETE /reservations/{id}/references/ib-manager` — release deletion block
+3. `DELETE /reservations/{id}/references/{ref}` — release deletion block
 
 ---
 
@@ -247,6 +246,7 @@ The minimal design is deliberately constrained to one host per Reservation. The 
 | Date | Decision | Rationale |
 |---|---|---|
 | 2026-04-01 | `Spec.NetworkID` carried on Reservation | External services (e.g. ib-manager) need the VPC association to know which partition or network resource to program. Carrying it in Spec avoids a separate lookup and makes the Reservation self-describing. |
+| 2026-04-01 | Deletion blocking via reference REST API, not direct finalizer writes | Per platform spec section 5.3, external services never write another service's finalizers directly. The reservation service exposes canonical `PUT`/`DELETE` reference endpoints and manages finalizers internally. |
 
 ---
 

--- a/designs/minimal-reservation-service.md
+++ b/designs/minimal-reservation-service.md
@@ -72,6 +72,7 @@ type OpenStackReservationLocalityPreference struct {
     // Level is the hierarchy level to prefer locality within (e.g. "scale_unit").
     Level string
     // FailurePolicy controls behaviour if locality cannot be achieved.
+    // "best-effort" proceeds without locality; "hard" rejects.
     FailurePolicy string
 }
 
@@ -359,7 +360,7 @@ All calls use mTLS; the caller's service account certificate is its identity.
 
 ### Creating a Reservation
 
-The region service (or operator tooling) creates a Reservation to claim a set of racks for a project. Example for a 2-rack dev slice with soft scale-unit locality:
+The region service (or operator tooling) creates a Reservation to claim a set of racks for a project. Example for a 2-rack dev slice with best-effort scale-unit locality:
 
 ```json
 POST /reservations
@@ -369,7 +370,7 @@ POST /reservations
     "topology": { "level": "rack", "count": 2 },
     "failure_policy": "hard"
   },
-  "locality_preference": { "level": "scale_unit", "failure_policy": "soft" }
+  "locality_preference": { "level": "scale_unit", "failure_policy": "best-effort" }
 }
 ```
 

--- a/designs/minimal-reservation-service.md
+++ b/designs/minimal-reservation-service.md
@@ -1,0 +1,247 @@
+# Minimal Reservation Service — Design
+
+## Overview
+
+The reservation service pre-allocates bare metal hosts for a VPC before any server is booted. It is OpenStack-specific: it talks to Nova and Ironic, and its internal CRDs model OpenStack concepts directly.
+
+**The problem it solves.** Bare metal host selection by Nova placement is opportunistic — at `nova boot` time, placement picks whatever host satisfies the flavour constraints. For workloads that need pre-boot infrastructure programming (IB partition assignment, network programming, topology-aware placement), the host must be known and programmed before the boot call. The reservation service pins the host early and holds it, allowing dependent services to complete their programming against a stable host identity before any instance runs.
+
+**What the reservation service does.** A caller creates a Reservation specifying a region, a flavour, and a set of readiness gates. The controller selects an available host of the right flavour, creates a Nova host aggregate containing that host, and records the aggregate ID in status. External services (e.g. ib-manager) receive a notification, perform their per-host programming, and signal readiness by setting a named condition on the Reservation via the reservation service REST API. Once all gates are satisfied and the Reservation is marked Ready, a caller can create a Server against it: the region service reads the aggregate ID from the Reservation and passes it to Nova as a scheduler hint, constraining placement to the pre-programmed host.
+
+**Scope.** This design covers the minimal case: one host per Reservation. Multi-host reservations (e.g. a full rack) are a planned expansion but not designed here.
+
+---
+
+## Design
+
+### CRD: `Reservation`
+
+The `Reservation` CRD is internal to the reservation service. Its schema uses OpenStack terminology directly — there is no provider abstraction.
+
+```go
+type ReservationSpec struct {
+    // Region in which to allocate a host
+    RegionID string
+    // Flavour determining which class of host to select
+    FlavorID string
+    // Condition types that must be True before this Reservation is usable.
+    // Copied verbatim from Region.Spec.ReadinessGates at creation time.
+    ReadinessGates []string
+}
+
+type ReservationStatus struct {
+    // Nova host aggregate UUID created for this Reservation
+    AggregateID string
+    // Ironic node UUIDs of the hosts assigned to this Reservation.
+    // Set by the controller after host selection; read by external services
+    // (e.g. ib-manager) to discover which hosts to program.
+    HostIDs []string
+    // Services that have registered a deletion block on this Reservation.
+    // The Reservation cannot be deleted while this list is non-empty.
+    ResourceReferences []string
+    // Standard Kubernetes conditions.
+    // Includes the controller-owned Ready condition and any gate conditions
+    // set by external services.
+    Conditions []metav1.Condition
+}
+```
+
+**Conditions:**
+- `Ready` — set True by the controller once the aggregate is created and hosts are assigned. This is the controller's own health signal, separate from the readiness gates.
+- Gate conditions (e.g. `ib.unikorn-cloud.org/partition-ready`) — set by external services via the REST API. The region service waits for all conditions named in `Spec.ReadinessGates` to be True before using this Reservation as a scheduler hint.
+
+A Reservation is usable when both `Ready == True` and all `Spec.ReadinessGates` conditions are True.
+
+### Controller
+
+On creation (DeletionTimestamp nil):
+
+```
+1. Select an available host
+       Query Ironic for nodes with a resource class matching FlavorID
+       Filter out nodes already referenced in another active Reservation
+       Pick one node
+
+2. Create Nova host aggregate
+       POST /compute/v2/os-aggregates
+       Add the selected host to the aggregate
+
+3. Record in status
+       Status.AggregateID = aggregate UUID
+       Status.HostIDs = [ironic node UUID]
+       Set Ready condition True
+```
+
+On deletion (DeletionTimestamp non-nil):
+
+```
+1. If Status.ResourceReferences is non-empty: requeue, do not proceed
+
+2. Delete Nova host aggregate
+       DELETE /compute/v2/os-aggregates/{id}
+
+3. Remove finalizer — Reservation is deleted
+```
+
+The controller adds a finalizer on creation to ensure the deletion path runs before the object is removed from etcd.
+
+### Host Selection
+
+A host is considered available if:
+- Its Ironic provision state is `available`
+- It is not in maintenance
+- Its resource class matches the requested flavour
+- Its Ironic node UUID does not appear in `Status.HostIDs` of any other active (non-deleting) Reservation in the same region
+
+Host selection is best-effort at creation time. If no host is available, the controller sets a condition (`HostUnavailable`) and requeues. It does not hold a lock between selection and aggregate creation — in the unlikely event of a race, the duplicate will be caught when the second reservation attempts to programme the same host (e.g. ib-manager will error on a conflicting GUID). The minimal service accepts this: single-host reservations with human-driven scheduling make races rare in practice.
+
+### Resource References
+
+External services that perform per-host programming register a deletion block on the Reservation while their programming is active. This prevents the aggregate from being torn down before the programming is reversed.
+
+The mechanism is a named entry in `Status.ResourceReferences`. The reservation service owns all writes to its own CRDs; external services add and remove references via the REST API.
+
+**Lifecycle:**
+
+```
+ib-manager programs IB partition
+    → POST .../reservations/{id}/references  body: {"name": "ib-manager"}
+    → reservation service appends "ib-manager" to Status.ResourceReferences
+
+Reservation deleted (DeletionTimestamp set)
+    → controller sees ResourceReferences non-empty, blocks
+
+ib-manager receives deletion event, reverses UFM programming
+    → DELETE .../reservations/{id}/references/ib-manager
+    → reservation service removes "ib-manager" from Status.ResourceReferences
+
+ResourceReferences now empty
+    → controller proceeds: deletes aggregate, removes finalizer
+```
+
+### Deletion Protocol
+
+Full end-to-end deletion sequence:
+
+```
+User deletes Reservation
+    │ DeletionTimestamp set
+    ▼
+Event bus fires → external services receive deletion notification
+    ib-manager:
+        Removes host GUIDs from UFM partition
+        DELETE .../reservations/{id}/references/ib-manager
+
+Reservation controller (requeued):
+    ResourceReferences empty?
+        No  → requeue
+        Yes → DELETE Nova aggregate
+              Remove finalizer
+              Reservation removed from etcd
+```
+
+---
+
+## REST API
+
+All endpoints are called by external services (region service, ib-manager). The reservation service writes to its own CRDs in response; callers never touch CRDs directly.
+
+| Method | Path | Caller | Purpose |
+|---|---|---|---|
+| `POST` | `/reservations` | Region service | Create a Reservation |
+| `GET` | `/reservations/{id}` | Region service, ib-manager | Read full Reservation state (host list, aggregate ID, conditions) |
+| `DELETE` | `/reservations/{id}` | Region service | Delete a Reservation |
+| `PUT` | `/reservations/{id}/conditions/{type}` | ib-manager | Set a named condition (e.g. `ib.unikorn-cloud.org/partition-ready: True`) |
+| `POST` | `/reservations/{id}/references` | ib-manager | Register a deletion block |
+| `DELETE` | `/reservations/{id}/references/{name}` | ib-manager | Release a deletion block |
+
+All calls use mTLS; the caller's service account certificate is its identity.
+
+---
+
+## Integration with the Region Service
+
+### Creating a Reservation
+
+The region service creates a Reservation when a Network is provisioned in an IB-capable region (or more generally, whenever the Region's `Spec.ReadinessGates` is non-empty). The Reservation is created with:
+- `RegionID` from the Network's region
+- `FlavorID` from the intended Server flavour
+- `ReadinessGates` copied verbatim from `Region.Spec.ReadinessGates`
+
+### Booting a Server
+
+```
+Region service creates Server
+
+    1. Fetch Reservation via reservation service REST API
+    2. Check Ready == True (aggregate created, host assigned)
+    3. Check all Spec.ReadinessGates conditions are True
+           If any are False or missing: Server stays pending, requeue
+
+    4. All gates satisfied:
+           Read Status.AggregateID from Reservation
+           POST /compute/v2/servers with scheduler hint:
+               os:scheduler_hints:
+                 aggregate_instance_extra_specs:
+                   unikorn-reservation: {reservation-id}
+           (Aggregate metadata key set by reservation service at aggregate creation time)
+```
+
+Nova placement selects the single host within the aggregate. Because only one host is in the aggregate and all pre-boot programming is complete, placement is deterministic.
+
+### Server-to-Reservation relationship
+
+In the minimal service, one Reservation is consumed by at most one Server. The region service is responsible for enforcing this: once a Server has been booted against a Reservation, the Reservation is considered consumed and should not be reused.
+
+---
+
+## Integration with ib-manager
+
+ib-manager subscribes to Reservation lifecycle events via the Kubernetes event bus (informer on the Reservation CRD). The envelope carries `ResourceID` and `DeletionTimestamp`.
+
+**On creation (DeletionTimestamp nil):**
+1. `GET /reservations/{id}` — fetch full state including `Status.HostIDs`
+2. Fetch flavour via region service REST API → `FlavorInfiniBandSpec.PortCount`
+3. If `PortCount == 0`: `PUT /reservations/{id}/conditions/ib.unikorn-cloud.org/partition-ready` True — done
+4. For each host in `Status.HostIDs`, query Ironic for IB port GUIDs
+5. Program UFM partition
+6. `POST /reservations/{id}/references` — register deletion block
+7. `PUT /reservations/{id}/conditions/ib.unikorn-cloud.org/partition-ready` True
+
+**On deletion (DeletionTimestamp non-nil):**
+1. `GET /reservations/{id}` — fetch current state
+2. Remove host GUIDs from UFM partition
+3. `DELETE /reservations/{id}/references/ib-manager` — release deletion block
+
+---
+
+## Event Bus
+
+The reservation service publishes Reservation lifecycle events to the Kubernetes event bus using the same envelope pattern as the region service: `ResourceID` and `DeletionTimestamp`. Subscribers (ib-manager) wire up a Kubernetes informer on the Reservation CRD type.
+
+`DeletionTimestamp == nil` → creation or update event.
+`DeletionTimestamp` non-nil → deletion in progress; subscriber should reverse its programming.
+
+---
+
+## Future Expansion
+
+The minimal design is deliberately constrained to one host per Reservation. The intended expansion path:
+
+- Add `Spec.Count int` (defaulting to 1) to support multi-host reservations
+- `Status.HostIDs` already a slice — no schema change needed for the multi-host case
+- Host selection logic generalises from "pick one" to "pick N"
+- Resource reference and gate mechanisms are unchanged
+- Further expansion to rack-level reservations would add a `Spec.Topology` field describing the grouping constraint (e.g. all hosts on the same top-of-rack switch)
+
+---
+
+## Open Questions
+
+1. **Host selection race:** The minimal service accepts a best-effort selection with no distributed lock. Is this acceptable for the target deployment, or does the host pool turn over fast enough that races are a real concern?
+
+2. **Aggregate scheduler hint mechanism:** The design uses `aggregate_instance_extra_specs` with a `unikorn-reservation` metadata key on the aggregate, requiring `AggregateInstanceExtraSpecsFilter` in Nova's scheduler filter list. This needs to be confirmed as enabled in the target deployment.
+
+3. **Flavour-to-resource-class mapping:** Host selection requires mapping `FlavorID` to an Ironic resource class. The mechanism for this lookup (via region service, directly from Nova, or via a local cache) is not yet specified.
+
+4. **Reservation ownership:** Who owns the lifecycle of a Reservation — is it created and deleted by the region service on behalf of a user, or is it a user-visible resource? For the minimal service, treating it as an internal implementation detail of the region service (not directly user-facing) is simplest.

--- a/designs/minimal-reservation-service.md
+++ b/designs/minimal-reservation-service.md
@@ -92,7 +92,7 @@ type OpenStackReservationSpec struct {
 }
 
 type OpenStackReservationStatus struct {
-    // RackIDs is the confirmed set of Ironic node UUIDs for the reserved racks.
+    // RackIDs is the confirmed set of rack identifiers reserved for this Reservation.
     // Set atomically at creation; immutable thereafter.
     RackIDs []string
     // LocalityLevel is the highest hierarchy level at which locality was achieved.

--- a/designs/minimal-reservation-service.md
+++ b/designs/minimal-reservation-service.md
@@ -225,9 +225,7 @@ On deletion (DeletionTimestamp non-nil):
 
 2. Remove CUSTOM_UNIKORN_CLAIMED trait from each host in Status.HostIDs
        For each host UUID:
-           GET /placement/resource_providers/{uuid}/traits
-           PUT /placement/resource_providers/{uuid}/traits
-               with CUSTOM_UNIKORN_CLAIMED removed, passing current generation
+           DELETE /v1/nodes/{uuid}/traits/CUSTOM_UNIKORN_CLAIMED
 
 3. Remove controller finalizer — Placement is deleted
 ```
@@ -261,17 +259,17 @@ Placement has a ~60-second sync lag from Ironic. To guard against stale data, ea
 Group the remaining candidates by rack. For each constraint in `Spec.SpreadConstraints`, distribute `MachineCount` hosts to satisfy `MaxSkew`. If `FailurePolicy: hard` and the constraint cannot be satisfied with available hosts, reject and return an error. Record actual skew per constraint in `SpreadResults`.
 
 **Step 5 — Claim the selected hosts.**
-For each selected host, set the `CUSTOM_UNIKORN_CLAIMED` trait using the Placement API's optimistic locking:
+For each selected host, set the `CUSTOM_UNIKORN_CLAIMED` trait via the Ironic API:
 
 ```
-GET /placement/resource_providers/{uuid}/traits   → current traits + generation
-PUT /placement/resource_providers/{uuid}/traits   → traits ∪ {CUSTOM_UNIKORN_CLAIMED}, generation N
-    409 Conflict → re-read generation and retry
-    If host now has CUSTOM_UNIKORN_CLAIMED set by a concurrent Placement:
-        rollback already-claimed hosts in this batch, restart from Step 2
+PUT /v1/nodes/{uuid}/traits/CUSTOM_UNIKORN_CLAIMED
 ```
 
-If no sufficient set of hosts is available, the controller sets a `HostUnavailable` condition and requeues. The Placement API's generation-based optimistic locking means that a concurrent claim on the same host produces a detectable 409 rather than a silent double-allocation. The worst-case outcome of a race is a retry, not an incorrect allocation.
+This call is idempotent. The Nova virt driver periodically syncs Ironic node traits to the Placement API resource provider; writing the trait directly to the Placement API would be overwritten on the next sync, so Ironic is the correct target.
+
+The Ironic traits API has no generation-based optimistic locking. Concurrent claim races are prevented instead by running Placement reconciliation with `MaxConcurrentReconciles: 1` and Kubernetes leader election, ensuring only one claim sequence executes at a time.
+
+If no sufficient set of hosts is available, the controller sets a `HostUnavailable` condition and requeues.
 
 ### Resource References
 
@@ -440,7 +438,7 @@ The reservation service publishes Placement lifecycle events to the event bus (s
 | 2026-04-01 | Deletion blocking via reference REST API, not direct finalizer writes | Per platform spec section 5.3, external services never write another service's finalizers directly. The reservation service exposes canonical `PUT`/`DELETE` reference endpoints and manages finalizers internally. |
 | 2026-04-01 | CRD named `OpenStackPlacement` | The CRD is OpenStack-specific (Ironic node UUIDs, Placement API traits). Making the provider explicit in the type name is consistent with the design's stated principle of no provider abstraction, and avoids naming conflicts if other provider types are added later. |
 | 2026-04-01 | Host selection via Placement API, cross-checked against Ironic | `GET /placement/resource_providers?resources=<class>:1` gives a more accurate availability view than querying Ironic directly — it reflects Nova allocations for nodes mid-deploy. Resource class is resolved from the flavour's `resources:CUSTOM_*` extra spec. Ironic is still checked to guard against Placement's ~60s sync lag. |
-| 2026-04-08 | Disjointness enforced via `CUSTOM_UNIKORN_CLAIMED` trait | Setting a custom trait on claimed hosts allows a single `required=!CUSTOM_UNIKORN_CLAIMED` filter in the host selection query, regardless of how many active Placements exist. The Placement API's per-resource-provider generation locking makes concurrent claims detectable and safely retriable. |
+| 2026-04-08 | Disjointness enforced via `CUSTOM_UNIKORN_CLAIMED` trait | Setting a custom trait on claimed hosts allows a single `required=!CUSTOM_UNIKORN_CLAIMED` filter in the host selection query, regardless of how many active Placements exist. The trait is set and removed via the Ironic API (not the Placement API directly) because Ironic is the source of truth for node traits; the Nova virt driver syncs Ironic → Placement and would overwrite any direct Placement API writes. Concurrent claim races are prevented by controller serialisation (`MaxConcurrentReconciles: 1` with leader election) rather than optimistic locking. |
 | 2026-04-08 | Topology constraints are a Placement concern, not a Reservation concern | Topology is a placement policy — where to put hosts — not a capacity policy. Rack affinity and spread are placement use cases. The Reservation layer expresses count and locality; the Placement expresses spread and host selection. |
 | 2026-04-09 | Reservation is a rack-level capacity boundary; Placement carves hosts from it | Separates the operator concern (which racks are dedicated to this project) from the workload concern (how to distribute N hosts across those racks). Gate services' contract is unchanged — they still see only a Placement with a fixed host list, a VPC, and readiness gates. |
 | 2026-04-09 | Servers target a specific host via `force_hosts` hint | Nova has no "boot into aggregate X" primitive. Since `Status.HostIDs` is resolved at Placement creation time, each server can be directed to a specific host directly. This avoids aggregate scheduler hints and makes host assignment explicit and auditable. |

--- a/designs/minimal-reservation-service.md
+++ b/designs/minimal-reservation-service.md
@@ -22,6 +22,10 @@ The `Reservation` CRD is internal to the reservation service. Its schema uses Op
 type ReservationSpec struct {
     // Region in which to allocate a host
     RegionID string
+    // VPC (Network) this Reservation is associated with.
+    // External services (e.g. ib-manager) use this to determine which
+    // partition or network resource to program for the reserved host.
+    NetworkID string
     // Flavour determining which class of host to select
     FlavorID string
     // Condition types that must be True before this Reservation is usable.
@@ -165,6 +169,7 @@ All calls use mTLS; the caller's service account certificate is its identity.
 
 The region service creates a Reservation when a Network is provisioned in an IB-capable region (or more generally, whenever the Region's `Spec.ReadinessGates` is non-empty). The Reservation is created with:
 - `RegionID` from the Network's region
+- `NetworkID` from the Network being provisioned
 - `FlavorID` from the intended Server flavour
 - `ReadinessGates` copied verbatim from `Region.Spec.ReadinessGates`
 
@@ -200,13 +205,14 @@ In the minimal service, one Reservation is consumed by at most one Server. The r
 ib-manager subscribes to Reservation lifecycle events via the Kubernetes event bus (informer on the Reservation CRD). The envelope carries `ResourceID` and `DeletionTimestamp`.
 
 **On creation (DeletionTimestamp nil):**
-1. `GET /reservations/{id}` — fetch full state including `Status.HostIDs`
+1. `GET /reservations/{id}` — fetch full state including `Spec.NetworkID` and `Status.HostIDs`
 2. Fetch flavour via region service REST API → `FlavorInfiniBandSpec.PortCount`
-3. If `PortCount == 0`: `PUT /reservations/{id}/conditions/ib.unikorn-cloud.org/partition-ready` True — done
-4. For each host in `Status.HostIDs`, query Ironic for IB port GUIDs
-5. Program UFM partition
-6. `POST /reservations/{id}/references` — register deletion block
-7. `PUT /reservations/{id}/conditions/ib.unikorn-cloud.org/partition-ready` True
+3. If `PortCount == 0`: set `ib.unikorn-cloud.org/partition-ready` True — done
+4. Look up the `IBPartition` for `Spec.NetworkID`
+5. For each host in `Status.HostIDs`, query Ironic for IB port GUIDs
+6. Program UFM partition (add GUIDs to the `IBPartition`)
+7. Register deletion block on the Reservation
+8. Set `ib.unikorn-cloud.org/partition-ready` True on the Reservation
 
 **On deletion (DeletionTimestamp non-nil):**
 1. `GET /reservations/{id}` — fetch current state
@@ -233,6 +239,14 @@ The minimal design is deliberately constrained to one host per Reservation. The 
 - Host selection logic generalises from "pick one" to "pick N"
 - Resource reference and gate mechanisms are unchanged
 - Further expansion to rack-level reservations would add a `Spec.Topology` field describing the grouping constraint (e.g. all hosts on the same top-of-rack switch)
+
+---
+
+## Decision Log
+
+| Date | Decision | Rationale |
+|---|---|---|
+| 2026-04-01 | `Spec.NetworkID` carried on Reservation | External services (e.g. ib-manager) need the VPC association to know which partition or network resource to program. Carrying it in Spec avoids a separate lookup and makes the Reservation self-describing. |
 
 ---
 

--- a/designs/minimal-reservation-service.md
+++ b/designs/minimal-reservation-service.md
@@ -16,9 +16,9 @@ The design uses two abstractions with separate concerns.
 
 A *Reservation* is a capacity boundary at the NVLink domain level (for simplicity, with some loss of accuracy: "rack"). It claims a set of racks exclusively for a project or purpose, preventing those racks from being used by any other Reservation.
 
-A *Placement* is an allocation carved from a Reservation. At allocation time, the controller selects a specific set of hosts from the Reservation's racks, applying spread constraints to control how those hosts are distributed. It refers to a VPC and is represented in OpenStack as a Nova host aggregate. The host list is fixed once the Placement is confirmed.
+A *Placement* is an allocation carved from a Reservation. At allocation time, the controller selects a specific set of hosts from the Reservation's racks, applying spread constraints to control how those hosts are distributed. The host list is fixed once the Placement is confirmed.
 
-Server creation is then unconditional fill: the topology work is done at Placement creation. The region service reads the aggregate ID from the Placement and passes it to Nova as a scheduler hint; no host selection or spread logic runs at server boot time. Any additional preparation (e.g., IB partition assignment) is already programmed before the first server boots.
+The topology work is done at Placement creation. When booting servers, the region service reads `Status.HostIDs` from the Placement and targets each server directly at a specific host; no host selection or spread logic runs at server boot time. Any additional preparation (e.g., IB partition assignment) is already programmed before the first server boots.
 
 **Scope.** This design covers the two-level model (Reservation + Placement), multi-host Placements with topology spread constraints, and the gate-based readiness protocol used to support additional host preparation.
 
@@ -182,10 +182,6 @@ type OpenStackPlacementSpec struct {
 }
 
 type OpenStackPlacementStatus struct {
-    // Nova host aggregate UUID created for this Placement.
-    // Also serves as the disjointness signal: hosts in this aggregate
-    // are ineligible for selection by any other Placement.
-    AggregateID string
     // Ironic node UUIDs of the hosts assigned to this Placement.
     // Set atomically at creation; immutable thereafter.
     // Read by gate services to discover which hosts to program.
@@ -201,33 +197,28 @@ type OpenStackPlacementStatus struct {
 ```
 
 **Conditions:**
-- `Allocated` — set True by the controller once hosts have been selected, added to the aggregate, and recorded in `Status.HostIDs`. This is the controller's own signal that the Placement has been populated.
+- `Allocated` — set True by the controller once hosts have been selected, claimed, and recorded in `Status.HostIDs`. This is the controller's own signal that the Placement has been populated.
 - Gate conditions (e.g. `ib.unikorn-cloud.org/partition-ready`) — set by external services via the REST API, as named in `Spec.ReadinessGates`.
 - `Ready` — set True by the controller only when `Allocated` is True and every condition named in `Spec.ReadinessGates` is also True.
 
 Consumers (e.g. the Server provisioner) wait only for `Ready == True`. They do not inspect individual gate conditions — that aggregation is the controller's responsibility.
 
-**Immutability.** `Status.HostIDs` does not change after it is first set. This is required so that the readiness gate fires exactly once and the programmed state of external services (e.g. the UFM partition) remains stable.
+**Immutability.** `Status.HostIDs` does not change after it is first set. This is required so that the readiness gate fires exactly once and the programmed state of external services remains stable.
 
 ### Placement Controller
 
 On creation (DeletionTimestamp nil):
 
 ```
-1. Select available hosts
+1. Select and claim available hosts
        See Host Selection below
 
-2. Create Nova host aggregate
-       POST /compute/v2/os-aggregates
-       Add the selected hosts to the aggregate
-
-3. Record in status
-       Status.AggregateID = aggregate UUID
+2. Record in status
        Status.HostIDs = [ironic node UUIDs]
        Status.SpreadResults = [per-constraint outcomes]
        Set Allocated condition True
 
-4. Recompute Ready
+3. Recompute Ready
        If Allocated == True and all Spec.ReadinessGates conditions are True:
            Set Ready condition True
 ```
@@ -239,8 +230,11 @@ On deletion (DeletionTimestamp non-nil):
    (inbound references signal that a dependent service has not yet
    reversed its programming)
 
-2. Delete Nova host aggregate
-       DELETE /compute/v2/os-aggregates/{id}
+2. Remove CUSTOM_UNIKORN_CLAIMED trait from each host in Status.HostIDs
+       For each host UUID:
+           GET /placement/resource_providers/{uuid}/traits
+           PUT /placement/resource_providers/{uuid}/traits
+               with CUSTOM_UNIKORN_CLAIMED removed, passing current generation
 
 3. Remove controller finalizer — Placement is deleted
 ```
@@ -249,7 +243,7 @@ The controller adds its own finalizer on creation to ensure the deletion path ru
 
 ### Host Selection
 
-The controller loads the parent Reservation to constrain the candidate set, then queries the OpenStack Placement API, then applies spread constraints.
+The controller loads the parent Reservation to constrain the candidate set, queries the OpenStack Placement API for unclaimed hosts, applies spread constraints, then claims the selected hosts.
 
 **Step 0 — Load the parent Reservation.**
 Verify `Status.State == Active`. Collect `Status.RackIDs`. All subsequent candidate enumeration is restricted to hosts whose rack membership is within this set.
@@ -257,30 +251,38 @@ Verify `Status.State == Active`. Collect `Status.RackIDs`. All subsequent candid
 **Step 1 — Resolve the resource class from the flavour.**
 The flavour's extra specs contain `resources:CUSTOM_BAREMETAL_LARGE=1` (or equivalent). The controller queries Nova for the flavour and reads the `resources:CUSTOM_*` key to obtain the resource class name.
 
-**Step 2 — Query Placement for available hosts.**
+**Step 2 — Query Placement for available, unclaimed hosts.**
 
 ```
-GET /placement/resource_providers?resources=CUSTOM_BAREMETAL_LARGE:1
+GET /placement/resource_providers?resources=CUSTOM_BAREMETAL_LARGE:1&required=!CUSTOM_UNIKORN_CLAIMED
 ```
 
-This returns only resource providers with free capacity. This is the correct source of truth because a node mid-deploy is already marked consumed in Placement even though its Ironic provision state is still `deploying`. The result is filtered to hosts whose rack membership is within the Reservation's `RackIDs`.
+This returns only resource providers with free capacity and without the claimed trait. The `CUSTOM_UNIKORN_CLAIMED` trait is set by this service on any host already allocated to a Placement, so the exclusion is O(1) regardless of how many active Placements exist. The result is filtered to hosts whose rack membership is within the Reservation's `RackIDs`.
 
-**Step 3 — Filter by aggregate membership.**
-Each candidate is checked against Nova: any host already a member of an existing Placement aggregate is excluded. This is the disjointness mechanism — it ensures a host cannot be assigned to more than one Placement without requiring cross-CRD scanning.
-
-**Step 4 — Cross-check against Ironic.**
+**Step 3 — Cross-check against Ironic.**
 Placement has a ~60-second sync lag from Ironic. To guard against stale data, each remaining candidate is checked directly against Ironic:
 - `provision_state == available`
 - `maintenance == false`
 
-**Step 5 — Apply spread constraints.**
+**Step 4 — Apply spread constraints.**
 Group the remaining candidates by rack. For each constraint in `Spec.SpreadConstraints`, distribute `MachineCount` hosts to satisfy `MaxSkew`. If `FailurePolicy: hard` and the constraint cannot be satisfied with available hosts, reject and return an error. Record actual skew per constraint in `SpreadResults`.
 
-If no sufficient set of hosts is available, the controller sets a `HostUnavailable` condition and requeues. Host selection is best-effort with no distributed lock — in the event of a race between two concurrent Placements selecting the same host, the aggregate-membership check reduces but does not eliminate the window.
+**Step 5 — Claim the selected hosts.**
+For each selected host, set the `CUSTOM_UNIKORN_CLAIMED` trait using the Placement API's optimistic locking:
+
+```
+GET /placement/resource_providers/{uuid}/traits   → current traits + generation
+PUT /placement/resource_providers/{uuid}/traits   → traits ∪ {CUSTOM_UNIKORN_CLAIMED}, generation N
+    409 Conflict → re-read generation and retry
+    If host now has CUSTOM_UNIKORN_CLAIMED set by a concurrent Placement:
+        rollback already-claimed hosts in this batch, restart from Step 2
+```
+
+If no sufficient set of hosts is available, the controller sets a `HostUnavailable` condition and requeues. The Placement API's generation-based optimistic locking means that a concurrent claim on the same host produces a detectable 409 rather than a silent double-allocation. The worst-case outcome of a race is a retry, not an incorrect allocation.
 
 ### Resource References
 
-External services that perform per-host programming register a deletion block on the Placement while their programming is active. This prevents the aggregate from being torn down before the programming is reversed.
+External services that perform per-host programming register a deletion block on the Placement while their programming is active. This prevents the hosts from being released and reclaimed before the programming is reversed.
 
 Per the platform spec (section 5.3), references cross service boundaries via the owning service's reference REST API — external services never write another service's finalizers directly. The reservation service exposes `PUT` and `DELETE` reference endpoints; internally it translates these into finalizer operations on its own CRD. The reference string format follows the canonical `{resource}.{group}/{uuid}` scheme produced by `GenerateResourceReference`.
 
@@ -299,7 +301,8 @@ Gate service receives deletion event, reverses programming
     → reservation service removes finalizer from Placement CRD
 
 No references remain
-    → controller proceeds: deletes aggregate, removes its own finalizer
+    → controller proceeds: removes CUSTOM_UNIKORN_CLAIMED from hosts,
+      removes its own finalizer
 ```
 
 ### Deletion Protocol
@@ -318,7 +321,7 @@ Event bus fires → gate services receive deletion notification
 Placement controller (requeued):
     GetResourceReferences() non-empty?
         Yes → requeue
-        No  → DELETE Nova aggregate
+        No  → Remove CUSTOM_UNIKORN_CLAIMED trait from each host
               Remove controller finalizer
               Placement removed from etcd
 
@@ -344,7 +347,7 @@ All endpoints are called by external services (region service, gate services). T
 | `GET` | `/reservations/{id}` | Region service | Read Reservation state and rack IDs |
 | `DELETE` | `/reservations/{id}` | Region service / operator | Delete a Reservation |
 | `POST` | `/placements` | Region service | Create a Placement |
-| `GET` | `/placements/{id}` | Region service, gate services | Read full Placement state (host list, aggregate ID, conditions) |
+| `GET` | `/placements/{id}` | Region service, gate services | Read full Placement state (host list, conditions) |
 | `DELETE` | `/placements/{id}` | Region service | Delete a Placement |
 | `PUT` | `/placements/{id}/conditions/{type}` | Gate service | Set a named condition |
 | `PUT` | `/placements/{id}/references/{name}` | Gate service | Register a deletion block (idempotent) |
@@ -374,7 +377,7 @@ POST /reservations
 
 ### Creating a Placement
 
-The region service creates a Placement when a Network is provisioned in an IB-capable region. The Placement is created with:
+The region service creates a Placement when a Network is provisioned in a region requiring pre-boot coordination. The Placement is created with:
 - `RegionID` from the Network's region
 - `ReservationID` of the Reservation covering this project's racks
 - `MachineCount` from the intended cluster size
@@ -393,15 +396,14 @@ Region service creates Server
            If False or absent: Server stays pending, requeue
 
     3. Ready == True:
-           Read Status.AggregateID from Placement
-           POST /compute/v2/servers with scheduler hint:
+           Assign a specific host from Status.HostIDs to this Server
+           (assignment tracked in the Server CRD; each host used at most once)
+           POST /compute/v2/servers with:
                os:scheduler_hints:
-                 aggregate_instance_extra_specs:
-                   unikorn-placement: {placement-id}
-           (Aggregate metadata key set by reservation service at aggregate creation time)
+                 force_hosts: [assigned-host-uuid]
 ```
 
-Nova selects any available host within the aggregate. Because all pre-boot programming is complete and the IB partition covers the full host set, placement is deterministic. Concurrent server creation calls against the same Placement are safe — Nova handles contention within the aggregate.
+Each server is targeted at a specific pre-selected host. Nova does not perform host selection — it is directed to the named host. Because all pre-boot programming is complete before any server boots, the host is guaranteed to be in the correct state.
 
 ---
 
@@ -456,12 +458,12 @@ The reservation service publishes Placement lifecycle events to the Kubernetes e
 |---|---|---|
 | 2026-04-01 | `Spec.NetworkID` carried on Placement | Gate services need the VPC association to know which network resource to program. Carrying it in Spec avoids a separate lookup and makes the Placement self-describing. |
 | 2026-04-01 | Deletion blocking via reference REST API, not direct finalizer writes | Per platform spec section 5.3, external services never write another service's finalizers directly. The reservation service exposes canonical `PUT`/`DELETE` reference endpoints and manages finalizers internally. |
-| 2026-04-01 | CRD named `OpenStackPlacement` | The CRD is OpenStack-specific (Nova aggregates, Ironic node UUIDs). Making the provider explicit in the type name is consistent with the design's stated principle of no provider abstraction, and avoids naming conflicts if other provider types are added later. |
+| 2026-04-01 | CRD named `OpenStackPlacement` | The CRD is OpenStack-specific (Ironic node UUIDs, Placement API traits). Making the provider explicit in the type name is consistent with the design's stated principle of no provider abstraction, and avoids naming conflicts if other provider types are added later. |
 | 2026-04-01 | Host selection via Placement API, cross-checked against Ironic | `GET /placement/resource_providers?resources=<class>:1` gives a more accurate availability view than querying Ironic directly — it reflects Nova allocations for nodes mid-deploy. Resource class is resolved from the flavour's `resources:CUSTOM_*` extra spec. Ironic is still checked to guard against Placement's ~60s sync lag. |
-| 2026-04-08 | Disjointness enforced via Nova aggregate membership | A host already in any Placement aggregate is excluded from selection by a new Placement. This uses Nova's own state as the source of truth rather than scanning CRDs, and provides the same guarantee with less coordination. |
+| 2026-04-08 | Disjointness enforced via `CUSTOM_UNIKORN_CLAIMED` trait | Setting a custom trait on claimed hosts allows a single `required=!CUSTOM_UNIKORN_CLAIMED` filter in the host selection query, regardless of how many active Placements exist. The Placement API's per-resource-provider generation locking makes concurrent claims detectable and safely retriable. |
 | 2026-04-08 | Topology constraints are a Placement concern, not a Reservation concern | Topology is a placement policy — where to put hosts — not a capacity policy. Rack affinity and spread are placement use cases. The Reservation layer expresses count and locality; the Placement expresses spread and host selection. |
 | 2026-04-09 | Reservation is a rack-level capacity boundary; Placement carves hosts from it | Separates the operator concern (which racks are dedicated to this project) from the workload concern (how to distribute N hosts across those racks). Gate services' contract is unchanged — they still see only a Placement with a fixed host list, a VPC, and readiness gates. |
-| 2026-04-09 | Server creation is unconditional aggregate fill | Spread constraints fire once at Placement creation. At server boot time there is no host selection and no spread logic — Nova picks any available host within the aggregate. This keeps the server provisioner simple and makes concurrent server creation safe. |
+| 2026-04-09 | Servers target a specific host via `force_hosts` hint | Nova has no "boot into aggregate X" primitive. Since `Status.HostIDs` is resolved at Placement creation time, each server can be directed to a specific host directly. This avoids aggregate scheduler hints and makes host assignment explicit and auditable. |
 
 ---
 
@@ -471,18 +473,18 @@ The current system boots servers directly via Nova with no pre-placement, no Pla
 
 ### Existing regions — no change required
 
-`Region.Spec.ReadinessGates` is a new optional field that defaults to empty. An empty gate list means no gates are required before a Placement is used as a scheduler hint — and with no Placement in the boot path at all, existing regions behave exactly as before. No operator action is needed for regions that do not have an IB fabric.
+`Region.Spec.ReadinessGates` is a new optional field that defaults to empty. An empty gate list means no Placement is needed before a server is booted, so existing regions behave exactly as before. No operator action is needed for regions that do not require pre-boot coordination.
 
-### New IB-capable regions — opt-in by operator
+### New regions requiring pre-boot coordination — opt-in by operator
 
-A region with an IB fabric is configured with `ib.unikorn-cloud.org/partition-ready` in `Region.Spec.ReadinessGates` at deploy time. Only these regions use Placements and gate-based pre-boot coordination. Enabling a gate service for a region is a single operator change to the Region definition; no flavour updates or server changes are needed.
+A region requiring pre-boot coordination (e.g. IB fabric programming) is configured with the relevant gate condition names in `Region.Spec.ReadinessGates` at deploy time. Only these regions use Placements and gate-based pre-boot coordination. Enabling a gate service for a region is a single operator change to the Region definition; no flavour updates or server changes are needed.
 
 ### Existing servers — no backfill
 
 Servers already running have no associated Placement. They do not need one: per-host programming for running servers was never performed (there were no gate services), and retrofitting a Placement to a running server would not change the hardware state. The Server provisioner must handle both cases:
 
 - **No Placement reference on the Server:** use the existing direct Nova placement path (current behaviour, unchanged).
-- **Placement reference present:** check all gates, then boot with the aggregate scheduler hint.
+- **Placement reference present:** check all gates, then boot targeting the assigned host.
 
 This conditional is the only place in the codebase where the old and new paths diverge. Existing servers continue to work without modification.
 
@@ -521,7 +523,7 @@ The Placement and Reservation controllers and handlers live inside `uni-region`.
 **Advantages:**
 - Host selection can use internal region service state directly — flavour-to-resource-class mapping, Ironic client, and existing host inventory are all in-process. No new endpoints needed.
 - One less service to deploy and operate.
-- The Placement is a natural extension of region concepts (flavours, hosts, aggregates).
+- The Placement is a natural extension of region concepts (flavours, hosts).
 
 **Disadvantages:**
 - The region service grows larger. Placement and Reservation lifecycle is a distinct concern from network and identity management.
@@ -546,9 +548,9 @@ The reservation service is a standalone binary with its own CRDs, API, and deplo
 
 ## Open Questions
 
-1. **Host selection race:** The minimal service accepts a best-effort selection with no distributed lock. The aggregate-membership filter reduces the race window but does not eliminate it: two concurrent Placements can both pass the filter before either has created its aggregate. Is this acceptable for the target deployment?
+1. **Host selection race:** The Placement API's generation-based optimistic locking makes concurrent host claims detectable: a 409 on `PUT /resource_providers/{uuid}/traits` signals that another Placement claimed the host first, requiring rollback of any already-claimed hosts in the batch and a restart of host selection. Is the retry overhead acceptable for the expected Placement creation rate?
 
-2. **Aggregate scheduler hint mechanism:** The design uses `aggregate_instance_extra_specs` with a `unikorn-placement` metadata key on the aggregate, requiring `AggregateInstanceExtraSpecsFilter` in Nova's scheduler filter list. This needs to be confirmed as enabled in the target deployment.
+2. ~~**Aggregate scheduler hint mechanism:**~~ Resolved — Nova aggregates are not used. Servers are directed to specific hosts via `force_hosts`.
 
 3. ~~**Flavour-to-resource-class mapping:**~~ Resolved — the resource class is read directly from the flavour's `resources:CUSTOM_*` extra spec. No separate mapping needed.
 

--- a/designs/minimal-reservation-service.md
+++ b/designs/minimal-reservation-service.md
@@ -244,7 +244,7 @@ The controller adds its own finalizer on creation to ensure the deletion path ru
 The controller loads the parent Reservation to constrain the candidate set, queries the OpenStack Placement API for unclaimed hosts, applies spread constraints, then claims the selected hosts.
 
 **Step 0 — Load the parent Reservation.**
-Verify `Status.State == Active`. Collect `Status.RackIDs`. All subsequent candidate enumeration is restricted to hosts whose rack membership is within this set.
+Verify `Status.State == Active`. Collect `Status.RackIDs`. All subsequent candidate enumeration is restricted to hosts whose rack membership is within this set. *(Implementation of rack membership lookup is pending resolution of Q6.)*
 
 **Step 1 — Resolve the resource class from the flavour.**
 The flavour's extra specs contain `resources:CUSTOM_BAREMETAL_LARGE=1` (or equivalent). The controller queries Nova for the flavour and reads the `resources:CUSTOM_*` key to obtain the resource class name.

--- a/designs/minimal-reservation-service.md
+++ b/designs/minimal-reservation-service.md
@@ -14,12 +14,12 @@ The reservation service pre-allocates bare metal hosts for a VPC before any serv
 
 ## Design
 
-### CRD: `Reservation`
+### CRD: `OpenStackReservation`
 
-The `Reservation` CRD is internal to the reservation service. Its schema uses OpenStack terminology directly — there is no provider abstraction.
+The `OpenStackReservation` CRD is internal to the reservation service. Its schema uses OpenStack terminology directly — there is no provider abstraction.
 
 ```go
-type ReservationSpec struct {
+type OpenStackReservationSpec struct {
     // Region in which to allocate a host
     RegionID string
     // VPC (Network) this Reservation is associated with.
@@ -33,7 +33,7 @@ type ReservationSpec struct {
     ReadinessGates []string
 }
 
-type ReservationStatus struct {
+type OpenStackReservationStatus struct {
     // Nova host aggregate UUID created for this Reservation
     AggregateID string
     // Ironic node UUIDs of the hosts assigned to this Reservation.
@@ -247,6 +247,7 @@ The minimal design is deliberately constrained to one host per Reservation. The 
 |---|---|---|
 | 2026-04-01 | `Spec.NetworkID` carried on Reservation | External services (e.g. ib-manager) need the VPC association to know which partition or network resource to program. Carrying it in Spec avoids a separate lookup and makes the Reservation self-describing. |
 | 2026-04-01 | Deletion blocking via reference REST API, not direct finalizer writes | Per platform spec section 5.3, external services never write another service's finalizers directly. The reservation service exposes canonical `PUT`/`DELETE` reference endpoints and manages finalizers internally. |
+| 2026-04-01 | CRD named `OpenStackReservation` | The CRD is OpenStack-specific (Nova aggregates, Ironic node UUIDs). Making the provider explicit in the type name is consistent with the design's stated principle of no provider abstraction, and avoids naming conflicts if other provider types are added later. |
 
 ---
 

--- a/designs/minimal-reservation-service.md
+++ b/designs/minimal-reservation-service.md
@@ -118,10 +118,7 @@ On creation (DeletionTimestamp nil):
    If failure_policy is "hard" and a single scale unit cannot supply
    the requested count, reject with a clean error.
 
-4. Conflict-check: no rack in the candidate set appears in any existing
-   active Reservation.
-
-5. Atomically write Status.RackIDs, Status.LocalityLevel, Status.State = Active.
+4. Atomically write Status.RackIDs, Status.LocalityLevel, Status.State = Active.
    Add controller finalizer.
 ```
 

--- a/designs/minimal-reservation-service.md
+++ b/designs/minimal-reservation-service.md
@@ -395,7 +395,7 @@ Each server is targeted at a specific pre-selected host. Nova does not perform h
 
 ## Integration with Gate Services
 
-A gate service subscribes to Placement lifecycle events via the Kubernetes event bus (informer on the `OpenStackPlacement` CRD). The envelope carries `ResourceID` and `DeletionTimestamp`.
+A gate service subscribes to Placement lifecycle events via the event bus. Event payloads carry `ResourceID` and `DeletionTimestamp`; gate services call `GET /placements/{id}` to retrieve current state.
 
 **On creation (DeletionTimestamp nil):**
 1. `GET /placements/{id}` — fetch full state including `Spec.NetworkID` and `Status.HostIDs`
@@ -415,10 +415,10 @@ A gate service subscribes to Placement lifecycle events via the Kubernetes event
 
 ## Event Bus
 
-The reservation service publishes Placement lifecycle events to the Kubernetes event bus using the same envelope pattern as the region service: `ResourceID` and `DeletionTimestamp`. Gate services wire up a Kubernetes informer on the `OpenStackPlacement` CRD type.
+The reservation service publishes Placement lifecycle events to the event bus (see [platform spec §5.4](../SPECIFICATION.md#54-event-bus)). Event payloads carry `resourceID` and `deletionTimestamp`; no resource state is embedded. Subscribers call `GET /placements/{id}` to retrieve current state.
 
-`DeletionTimestamp == nil` → creation or update event.
-`DeletionTimestamp` non-nil → deletion in progress; subscriber should reverse its programming.
+`deletionTimestamp == nil` → creation or update event.
+`deletionTimestamp` non-nil → deletion in progress; subscriber should reverse its programming.
 
 ---
 

--- a/designs/minimal-reservation-service.md
+++ b/designs/minimal-reservation-service.md
@@ -250,6 +250,40 @@ The minimal design is deliberately constrained to one host per Reservation. The 
 
 ---
 
+## Service Placement
+
+Two deployment options exist. The choice has not yet been made.
+
+### Option A: Embedded in the Region Service
+
+The reservation controller and handler live inside `uni-region`. The `Reservation` CRD belongs to the region service API group.
+
+**Advantages:**
+- Host selection can use internal region service state directly — flavour-to-resource-class mapping, Ironic client, and existing host inventory are all in-process. No new endpoints needed.
+- One less service to deploy and operate.
+- The Reservation is a natural extension of region concepts (flavours, hosts, aggregates).
+
+**Disadvantages:**
+- The region service grows larger. Reservation lifecycle (host selection, aggregate management, gate coordination) is a distinct concern from network and identity management.
+- All consumers (ib-manager, future gate services) already call the region service; adding reservation endpoints there conflates two separate responsibilities.
+
+### Option B: Separate Service (`uni-reservation`)
+
+The reservation service is a standalone binary with its own CRDs, API, and deployment.
+
+**Advantages:**
+- Clean separation of concerns. The reservation service owns host pre-allocation; the region service owns networks and identities.
+- Independently deployable and scalable.
+- The service boundary makes the gate protocol explicit — ib-manager calls `uni-reservation`, not `uni-region`.
+
+**Disadvantages:**
+- Host selection requires knowing which Ironic nodes are available for a given flavour. This state currently lives in the region service. A separate service would need either:
+  - A new region service endpoint — "list available hosts for flavour X" — which does not exist today, or
+  - Its own Ironic credentials and flavour-to-resource-class mapping logic, duplicating region service internals.
+- Additional operational complexity: new deployment, new mTLS certificate, new RBAC role.
+
+---
+
 ## Open Questions
 
 1. **Host selection race:** The minimal service accepts a best-effort selection with no distributed lock. Is this acceptable for the target deployment, or does the host pool turn over fast enough that races are a real concern?
@@ -259,3 +293,5 @@ The minimal design is deliberately constrained to one host per Reservation. The 
 3. **Flavour-to-resource-class mapping:** Host selection requires mapping `FlavorID` to an Ironic resource class. The mechanism for this lookup (via region service, directly from Nova, or via a local cache) is not yet specified.
 
 4. **Reservation ownership:** Who owns the lifecycle of a Reservation — is it created and deleted by the region service on behalf of a user, or is it a user-visible resource? For the minimal service, treating it as an internal implementation detail of the region service (not directly user-facing) is simplest.
+
+5. **Service placement:** Should the reservation service be embedded in `uni-region` (Option A) or deployed as a separate service `uni-reservation` (Option B)? See the Service Placement section. The deciding factor is likely host selection: if a "list available hosts for flavour" endpoint can be added to the region service, Option B becomes more viable. If not, Option A avoids duplicating Ironic and flavour-mapping logic.

--- a/designs/minimal-reservation-service.md
+++ b/designs/minimal-reservation-service.md
@@ -250,6 +250,50 @@ The minimal design is deliberately constrained to one host per Reservation. The 
 
 ---
 
+## Migration
+
+The current system boots servers directly via Nova with no pre-placement, no Reservations, and no readiness gates. The migration must be non-breaking for existing regions and existing servers.
+
+### Existing regions — no change required
+
+`Region.Spec.ReadinessGates` is a new optional field that defaults to empty. An empty gate list means no gates are required before a Reservation is used as a scheduler hint — and with no Reservation in the boot path at all, existing regions behave exactly as before. No operator action is needed for regions that do not have an IB fabric.
+
+### New IB-capable regions — opt-in by operator
+
+A region with an IB fabric is configured with `ib.unikorn-cloud.org/partition-ready` in `Region.Spec.ReadinessGates` at deploy time. Only these regions use Reservations and gate-based pre-boot coordination. Enabling ib-manager for a region is a single operator change to the Region definition; no flavour updates or server changes are needed.
+
+### Existing servers — no backfill
+
+Servers already running have no associated Reservation. They do not need one: IB partitions for running servers were never programmed (there was no ib-manager), and retrofitting a Reservation to a running server would not change the hardware state. The Server provisioner must handle both cases:
+
+- **No Reservation reference on the Server:** use the existing direct Nova placement path (current behaviour, unchanged).
+- **Reservation reference present:** check all gates, then boot with the aggregate scheduler hint.
+
+This conditional is the only place in the codebase where the old and new paths diverge. Existing servers continue to work without modification.
+
+### Schema changes are additive
+
+All CRD changes introduced by this design are additive optional fields:
+
+| Resource | New field | Default | Impact on existing resources |
+|---|---|---|---|
+| `Region` | `Spec.ReadinessGates []string` | `[]` (empty) | None — existing Regions have no gates |
+| `Reservation` | Entire new CRD | — | None — no existing Reservations |
+| `Flavor` | `Spec.InfiniBand.PortCount int` | `0` | None — existing Flavours have zero IB ports |
+
+No data migration is required. Existing resources are valid under the new schema without modification.
+
+### Rollout order
+
+1. Deploy the updated region service with `Region.Spec.ReadinessGates` support and the conditional Server provisioner path.
+2. Deploy the reservation service (or activate it within `uni-region` depending on the placement decision).
+3. Deploy ib-manager.
+4. For each IB-capable region, add `ib.unikorn-cloud.org/partition-ready` to `Region.Spec.ReadinessGates`.
+
+Steps 1–3 have no user-visible effect. Step 4 activates the new path for that region only.
+
+---
+
 ## Service Placement
 
 Two deployment options exist. The choice has not yet been made.


### PR DESCRIPTION
This introduces a design for a minimal, internal Reservation service. This serves two purposes:

1. it gives a base for a more sophisticated reservation service, by adding an API type, and modifying the region service to account for reservations;
2. it provides machinery so that other controllers can work on hosts before they are booted, which will be guaranteed to work with 1.
