### PR TITLE
docs(load-balancers): add region v2 and OpenStack provider specifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ The **[Unified Architectural Specification](SPECIFICATION.md)** is the single so
 
 Each service repository contains a `CLAUDE.md` that references this document. AI agents should fetch the raw content of `SPECIFICATION.md` directly for full platform context.
 
+## Region Specifications
+
+Public Region abstractions that sit above provider-specific behavior are documented separately:
+
+* [Load Balancers v2](specifications/region/load-balancers.md)
+
 ## Provider-Specific Specifications
 
 Provider-specific configuration that sits below the platform abstraction boundary is documented separately:
@@ -14,3 +20,4 @@ Provider-specific configuration that sits below the platform abstraction boundar
 
 * [Flavor and Image Handling](specifications/providers/openstack/flavors_and_images.md)
 * [External Networks](specifications/providers/openstack/external-networks.md)
+* [Load Balancers](specifications/providers/openstack/load-balancers.md)

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -499,7 +499,9 @@ Quota allocation uses a two-phase reservation model. The handler makes a soft re
 
 - List operations filter by organisation and project via label selectors derived from the principal's ACL.
 - Post-list RBAC filtering (`rbac.AllowProjectScope`) is applied in-process where label selectors alone cannot encode the access policy.
-- Tag-based filtering (`spec.tags`) is applied after the list, not as a label selector.
+- Tags are part of the standard resource metadata inherited by UNI resources and exposed in the public API at `metadata.tags`.
+- Tag-based filtering matches the resource tags exposed at `metadata.tags` and is applied after the list, not as a label selector.
+- The backing CRD or storage field used to persist tags is an implementation detail and does not define the public filtering contract.
 - List results are sorted stably (by name) to ensure deterministic ordering.
 
 ### 7.9 Error Handling and Propagation

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -165,7 +165,7 @@ A **principal** is the originating end-user responsible for a resource. The prin
 
 A **proxy** is a service provisioning resources on behalf of a principal. The proxy carries its own service identity for transport authentication, but the principal it is acting for is propagated separately in the request context.
 
-At the public API boundary, the principal is derived from token introspection (the actor claim) combined with the organisation and project from the HTTP path. This derivation happens once, at the boundary, and the result is threaded through all downstream processing.
+At the public API boundary, the principal is derived from token introspection (the actor claim) combined with the organisation and project from the request (path segments, query parameters, or the resource spec, depending on the API surface). This derivation happens once, at the boundary, and the result is threaded through all downstream processing.
 
 A proxy may provision resources in its own tenancy or in the principal's tenancy, depending on whether direct end-user access to those resources is appropriate.
 
@@ -648,7 +648,7 @@ Every audit log entry must carry the following structured fields:
 | `component` | Service name and version |
 | `actor` | Principal subject |
 | `operation` | HTTP verb |
-| `scope` | `organisationID` and `projectID` from path |
+| `scope` | `organisationID` and `projectID` from the request |
 | `resource` | Resource type and ID |
 | `result` | HTTP status code |
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -102,7 +102,7 @@ The Nscale Cloud Platform is a cloud-agnostic PaaS for AI/ML workloads. Each ser
 | Service | Role | Owns |
 |---|---|---|
 | Identity | Identity Service | Organisation, Project, User, Group, Role, OAuth2Client |
-| Region | Region Service | Region, CloudIdentity, Network, PhysicalNetwork, ServerGroup |
+| Region | Region Service | Region, CloudIdentity, Network, PhysicalNetwork, ServerGroup, LoadBalancer |
 | Compute | Compute Service | Server |
 | Kubernetes | Kubernetes Service | ClusterManager, Cluster |
 | Core | Core Library | (shared library — no resources) |

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -321,6 +321,7 @@ Status propagation is orthogonal to deletion semantics. Where an edge carries st
 - For intra-service edges, Kubernetes watches on the target resource type satisfy this directly.
 - For cross-service edges, the event bus provides the stimulus.
 - Status propagation upward may be carried by any edge type. Whether a given edge carries it is a declaration made when the resource type is defined. It is not assumed.
+- If lifecycle ownership and status observation point in opposite directions between the same resource pair, the resource-type spec may document them as separate directed relationships with different property sets. This is a clarification of how to describe the graph; it does not change the deletion model.
 
 ### 5.9 Deletion Propagation Mechanisms
 

--- a/specifications/providers/openstack/load-balancers.md
+++ b/specifications/providers/openstack/load-balancers.md
@@ -20,6 +20,10 @@ The initial OpenStack implementation is:
 - Public API remains provider-agnostic
 - Hidden load-balancing algorithm fixed to `ROUND_ROBIN`
 
+Terminated TLS remains out of scope so Kubernetes and CCM-managed workloads retain end-to-end TLS and, where used, client-certificate visibility at the workload.
+
+Regions that expose this API are assumed to provide Octavia with the Amphora driver. Unsupported regions are out of scope for this version rather than modeled as a discoverable feature flag.
+
 OVN compatibility is explicitly out of scope for this version, since OVN does not support VLANs currently.
 
 ## Resource Mapping
@@ -60,22 +64,9 @@ The following remain at provider defaults:
 - `timeout_member_connect`
 - `timeout_tcp_inspect`
 
-## Controller and Persistence Model
+## Controller and Live-Discovery Model
 
-The implementation adds:
-
-- A new user-facing Region CRD: `LoadBalancer`
-- A new OpenStack persistence CRD: `OpenstackLoadBalancer`
-
-`OpenstackLoadBalancer` must persist at minimum:
-
-| Scope | Required fields |
-|---|---|
-| Load balancer | `loadBalancerID`, `vipPortID`, `floatingIPID?` |
-| Listener | `name`, `listenerID`, `poolID`, `healthMonitorID?`, last applied `allowedCidrs`, last applied `idleTimeoutSeconds?`, last applied `proxyProtocolV2` |
-| Member | `listenerName`, `address`, `memberID`, `port` |
-
-Listener reconciliation is keyed by the public `listener.name`, not by provider-generated IDs alone. Member persistence must be scoped per listener or pool because the same address may appear in multiple pools with different ports.
+`LoadBalancer` is the only Region-owned resource in this design. The Octavia and Neutron objects below are implementation projections of that single Region resource, not a second public or persistent Region resource model.
 
 Extend the Region provider interfaces with:
 
@@ -83,7 +74,7 @@ Extend the Region provider interfaces with:
 - `DeleteLoadBalancer`
 - `UpdateLoadBalancerState`
 
-These are in-process Go interfaces called directly by the controller within the Region service. They do not cross an API boundary and require no authentication classification or OpenAPI annotation.
+These are in-process Go interfaces called directly by the controller within the Region service. They are not API endpoints, so OpenAPI annotation and authentication-classification language is not applicable.
 
 Provider contract:
 
@@ -91,19 +82,32 @@ Provider contract:
 - `DeleteLoadBalancer` fully tears down all provider resources, including floating IPs.
 - `UpdateLoadBalancerState` refreshes derived status such as VIP and public IP.
 
+No provider-specific persistence CRD or stored "last applied" snapshot is used. Reconcile rediscovers provider resources from live Octavia and Neutron state on every pass.
+
+Live discovery uses deterministic names and identities:
+
+- load balancer name: `lb-{loadBalancerUUID}`
+- listener name: `lb-{loadBalancerUUID}-{listenerName}`
+- pool name: `lb-{loadBalancerUUID}-{listenerName}-pool`
+- health monitor name: `lb-{loadBalancerUUID}-{listenerName}-hm`
+- member identity: `(poolID, address, port)`
+- floating IP lookup: by VIP port ID
+
 ## Reconciliation Semantics
 
 The OpenStack provider implementation must satisfy the following behavior:
 
-- Provider-side reconcile is idempotent across repeated calls. If the controller crashes mid-reconcile, the next reconcile pass reads persisted IDs from `OpenstackLoadBalancer` and resumes from the last successful state. Partial provider state is handled by the subsequent reconcile pass without manual intervention.
+- Provider-side reconcile is idempotent across repeated calls and controller restarts. Every reconcile pass discovers the live Octavia and Neutron objects for the load balancer by deterministic name or identity and resumes from the observed provider state.
+- Desired state is always diffed against live Octavia and Neutron state, never against stored "last applied" state.
 - Listener reconciliation is keyed by stable public `listener.name`.
 - A listener rename is handled as delete-and-create of the provider listener and pool subtree.
+- Changing a listener's `protocol` or `port` while keeping the same `listener.name` is reconciled as an in-place Octavia listener update, not as delete-and-create.
 - Listener CIDRs are updated in place.
 - Listener idle timeout is updated in place.
 - Health monitor create, delete, and parameter updates are reconciled in place.
 - Member sets and member ports are updated in place.
 - `proxyProtocolV2` changes for TCP listeners are reconciled without changing the public resource contract.
-- Toggling `publicIP` attaches or detaches the Neutron floating IP from the VIP port.
+- Toggling `publicIP` attaches or detaches the Neutron floating IP from the VIP port discovered for the load balancer VIP.
 
 ## Public Status Exposure
 
@@ -151,9 +155,9 @@ On deletion:
 
 1. The controller detects the deletion timestamp on the `LoadBalancer` resource.
 2. While inbound references or owned children exist, the controller retries silently (`ErrYield`).
-3. The controller calls `DeleteLoadBalancer`, which fully tears down all Octavia resources (listeners, pools, members, health monitors, the load balancer itself), detaches and deletes any Neutron floating IP, and clears the `OpenstackLoadBalancer` persistence state.
-4. The controller releases any outbound references (none in the current design, since the Network edge is a dependency, not a consumption).
-5. Only after all provider resources and references are cleaned up does the controller remove the finalizer.
+3. The controller calls `DeleteLoadBalancer`, which fully tears down all Octavia resources (listeners, pools, members, health monitors, the load balancer itself) and detaches and deletes any Neutron floating IP.
+4. The controller releases any outbound references (none in the current design, since the Network edge is a dependency, not a consumption) and releases the committed load balancer quota allocation or any still-active reservation.
+5. Only after all provider resources, quota state, and references are cleaned up does the controller remove the finalizer.
 
 ## Downstream Error Handling
 
@@ -204,13 +208,21 @@ This provider mapping does not include:
 - Additional VIPs
 - Listener connection limits
 
+Floating-IP/public-IP quota is also out of scope for this document because that quota is shared across resource types, including instances, and must be defined once at the platform level.
+
 ## Acceptance Criteria
 
 Implementation handoff must include tests that cover:
 
+- List by `tag` and verify the filter matches the public API representation of tags at `metadata.tags`.
+- Verify the load balancer public API does not expose a load-balancer-specific `spec.tags` field.
+- Verify any backing Region CRD persistence of tags is treated as internal and does not affect API semantics.
 - Create a private TCP load balancer with one or more IP-address members.
 - Create a private UDP load balancer with one or more IP-address members.
 - Create a public load balancer with `publicIP=true`.
+- Create within the load balancer quota and verify success.
+- Reject create over the load balancer quota with `403 forbidden`.
+- Delete a load balancer and verify the load balancer quota allocation is released.
 - Create a load balancer with `members: []` and verify VIP allocation succeeds while `Available` stays false until a backend becomes effective.
 - Create one load balancer with multiple listeners and different `allowedCidrs` per listener.
 - Create a TCP listener with `proxyProtocolV2=true`.
@@ -224,6 +236,8 @@ Implementation handoff must include tests that cover:
 - Update listener CIDRs in place.
 - Verify `allowedCidrs: []` and omitted `allowedCidrs` both mean unrestricted after update.
 - Update listener idle timeout in place.
+- Update a listener's `protocol` in place while keeping the same name.
+- Update a listener's `port` in place while keeping the same name.
 - Update a listener by name and verify rename is treated as delete-and-create.
 - Update member sets and member ports in place.
 - Create, remove, and update a health monitor in place.
@@ -237,11 +251,14 @@ Implementation handoff must include tests that cover:
 - Allow the same address in different pools.
 - Allow the same address with different ports in one pool.
 - Verify network deletion triggers load balancer deletion and is not blocked by the load balancer.
+- Verify network deletion while the load balancer controller is down still causes load balancer deletion after restart and reconcile.
 - Verify member address and port updates are reconciled to Octavia in place.
+- Restart the controller after a partial reconcile and verify existing Octavia resources are rediscovered without any provider persistence object.
 - Verify Amphora Octavia resources, floating IPs, and references are fully cleaned up on delete.
 - Verify `PUT` returns `409 conflict` when the resource version has advanced (conflict detection).
 - Verify `DELETE` on an already-deleting resource returns `202` without re-triggering deletion (idempotent delete).
 - Reject load balancer creation when the network is in a different organisational scope (co-location validation returns `422`).
 - Verify the controller finalizer prevents premature garbage collection during deprovisioning.
 - Verify RBAC enforcement for the `region:loadbalancers:v2` scope on all endpoints.
-- Verify behavior when `region.features.loadBalancers` is `false` for the target region.
+
+Do not add a load-balancer-only floating-IP/public-VIP quota test in this version. That quota remains a shared platform-level follow-up across instances and load balancers.

--- a/specifications/providers/openstack/load-balancers.md
+++ b/specifications/providers/openstack/load-balancers.md
@@ -129,7 +129,7 @@ The following are not exposed in v1:
 
 For status derivation, an effective backend is a member that has been successfully provisioned as an Octavia pool member.
 
-Every reconcile pass, successful or not, must update the `Available` condition before returning. This is unconditional per [SPECIFICATION.md §8.4](../../SPECIFICATION.md).
+Every reconcile pass, successful or not, must update the `Available` condition before returning. This is unconditional per [SPECIFICATION.md §8.4](../../../SPECIFICATION.md).
 
 | Octavia or local state | Region condition mapping | Reconcile return | Queue behavior |
 |---|---|---|---|
@@ -141,11 +141,11 @@ Every reconcile pass, successful or not, must update the `Available` condition b
 
 The zero-members case uses `ConditionReasonProvisioning` because the load balancer is not yet fully operational, even though the Octavia LB itself may be `ACTIVE` with a VIP allocated. This is the best-fit standard reason within the platform's condition vocabulary. Callers should not interpret `ConditionReasonProvisioning` as necessarily meaning infrastructure provisioning is in progress.
 
-If the status write itself fails (e.g., resource version conflict), the controller requeues with a fixed timeout and does not return an error (status write failure is transient per [SPECIFICATION.md §8.4](../../SPECIFICATION.md)).
+If the status write itself fails (e.g., resource version conflict), the controller requeues with a fixed timeout and does not return an error (status write failure is transient per [SPECIFICATION.md §8.4](../../../SPECIFICATION.md)).
 
 ## Finalizer Lifecycle
 
-The controller adds its finalizer to the `LoadBalancer` resource before performing any provisioning work per [SPECIFICATION.md §8.5](../../SPECIFICATION.md).
+The controller adds its finalizer to the `LoadBalancer` resource before performing any provisioning work per [SPECIFICATION.md §8.5](../../../SPECIFICATION.md).
 
 On deletion:
 
@@ -157,7 +157,7 @@ On deletion:
 
 ## Downstream Error Handling
 
-When the controller receives error responses from Octavia or Neutron API calls, it classifies them per [SPECIFICATION.md §8.7](../../SPECIFICATION.md):
+When the controller receives error responses from Octavia or Neutron API calls, it classifies them per [SPECIFICATION.md §8.7](../../../SPECIFICATION.md):
 
 | Octavia/Neutron response | Treatment |
 |---|---|
@@ -167,19 +167,19 @@ When the controller receives error responses from Octavia or Neutron API calls, 
 | 403 | Genuine error. Surface as `ConditionReasonErrored`. Permission failure will not resolve without intervention. |
 | 401 | Transient for a bounded number of retries (credential refresh). If persistent, surface as `ConditionReasonErrored`. |
 
-The controller must not poll Octavia to check whether dependent resources are ready. Dependency readiness is inferred from local status conditions via status propagation upward per [SPECIFICATION.md §8.7](../../SPECIFICATION.md).
+The controller must not poll Octavia to check whether dependent resources are ready. Dependency readiness is inferred from local status conditions via status propagation upward per [SPECIFICATION.md §8.7](../../../SPECIFICATION.md).
 
 ## Deadlock Detection
 
-On every reconcile pass of a load balancer in `DELETING` state, the controller checks the age of the deletion timestamp. If the timestamp has been set for longer than 10 minutes and inbound references are still present, the controller emits a structured zap error log entry per [SPECIFICATION.md §8.8](../../SPECIFICATION.md).
+On every reconcile pass of a load balancer in `DELETING` state, the controller checks the age of the deletion timestamp. If the timestamp has been set for longer than 10 minutes and inbound references are still present, the controller emits a structured zap error log entry per [SPECIFICATION.md §8.8](../../../SPECIFICATION.md).
 
 The log entry must include as discrete structured zap fields (indexable in Loki): resource type (`LoadBalancer`), resource ID, deletion timestamp, elapsed duration, and the full set of blocking reference strings.
 
 ## Observability
 
-The controller follows the platform observability requirements in [SPECIFICATION.md §9](../../SPECIFICATION.md):
+The controller follows the platform observability requirements in [SPECIFICATION.md §9](../../../SPECIFICATION.md):
 
-- **Structured logging**: every reconcile pass, state transition (Octavia state changes, floating IP attach/detach), reference operation, and requeue decision is logged with resource type and resource ID as structured zap fields. Verbose controller logging per [SPECIFICATION.md §9.1](../../SPECIFICATION.md).
+- **Structured logging**: every reconcile pass, state transition (Octavia state changes, floating IP attach/detach), reference operation, and requeue decision is logged with resource type and resource ID as structured zap fields. Verbose controller logging per [SPECIFICATION.md §9.1](../../../SPECIFICATION.md).
 - **Distributed tracing**: a span is created for every controller reconcile pass. Outbound calls to Octavia and Neutron propagate trace context.
 - **Metrics**: the controller emits reconcile duration (histogram), reconcile outcome (counter by success/transient/error), work queue depth (gauge), and reference operation count (counter by add/remove and outcome). Metric names follow Prometheus conventions: `snake_case`, service-prefixed, with unit suffixes.
 

--- a/specifications/providers/openstack/load-balancers.md
+++ b/specifications/providers/openstack/load-balancers.md
@@ -8,7 +8,7 @@ The initial provider assumption is Octavia with the Amphora driver. This is an i
 
 | Version | Date | Notes |
 |---|---|---|
-| v0.3 | 2026-04-11 | Members use IP addresses directly; removed compute-instance lifecycle reconciliation |
+| v0.3 | 2026-04-11 | Members use IP addresses directly; removed compute-instance lifecycle reconciliation; `Available=True` requires `status.vipAddress` populated |
 | v0.2 | 2026-04-10 | Review update: listener-name identity, dependency-triggered deletion, stale-member withdrawal, and clarified status mapping |
 | v0.1 | 2026-04-10 | Initial draft |
 
@@ -133,7 +133,7 @@ For status derivation, an effective backend is a member that has been successful
 |---|---|
 | `PENDING_CREATE` or `PENDING_UPDATE` | `Available=False` with reason `ConditionReasonProvisioning` |
 | `PENDING_DELETE` or local delete flow | `Available=False` with reason `ConditionReasonDeprovisioning` |
-| `ACTIVE` with at least one effective backend | `Available=True` with reason `ConditionReasonProvisioned` |
+| `ACTIVE` with at least one effective backend and `status.vipAddress` populated | `Available=True` with reason `ConditionReasonProvisioned` |
 | `ERROR` | `Available=False` with reason `ConditionReasonErrored` |
 | Zero members or zero effective backends | `Available=False` with reason `ConditionReasonProvisioning` |
 

--- a/specifications/providers/openstack/load-balancers.md
+++ b/specifications/providers/openstack/load-balancers.md
@@ -1,0 +1,178 @@
+# OpenStack Load Balancers
+
+This document defines the initial OpenStack provider mapping for the public Region v2 load balancer abstraction in [Region Load Balancers v2](../../region/load-balancers.md).
+
+The initial provider assumption is Octavia with the Amphora driver. This is an implementation constraint for v1, not a permanent public API commitment.
+
+## Changelog
+
+| Version | Date | Notes |
+|---|---|---|
+| v0.1 | 2026-04-10 | Initial draft |
+
+## Scope and Assumptions
+
+The initial OpenStack implementation is:
+
+- Octavia Amphora only
+- Layer 4 only
+- IPv4 only
+- Public API remains provider-agnostic
+- Hidden load-balancing algorithm fixed to `ROUND_ROBIN`
+
+OVN compatibility is explicitly out of scope for this version, since OVN does not support VLANs currently.
+
+## Resource Mapping
+
+The public abstraction maps to Octavia and Neutron as follows:
+
+| Region abstraction | OpenStack resource or behavior |
+|---|---|
+| One Region load balancer | One Octavia load balancer |
+| One Region listener | One Octavia listener |
+| One Region pool | One Octavia pool |
+| One Region member | One Octavia member using the resolved compute private IP and configured member port |
+| `publicIP=true` | One Neutron floating IP attached to the VIP port |
+| Listener `allowedCidrs` | Octavia listener allowed-CIDRs feature (`allowed_cidrs` API field) |
+| Hidden public algorithm | Octavia `ROUND_ROBIN` |
+
+`networkId` is the tenant network used for both the VIP subnet selection and backend member reachability.
+
+## Protocol and Health-Monitor Mapping
+
+| Public listener settings | Octavia listener protocol | Octavia pool protocol | Octavia health monitor type |
+|---|---|---|---|
+| `tcp` with `proxyProtocolV2=false` | `TCP` | `TCP` | `TCP` |
+| `tcp` with `proxyProtocolV2=true` | `TCP` | `PROXYV2` | `TCP` |
+| `udp` | `UDP` | `UDP` | `UDP-CONNECT` |
+
+`proxyProtocolV2=true` means the backend hop uses PROXY protocol version 2. The client-facing listener protocol remains plain TCP.
+
+## Timeout Mapping
+
+`idleTimeoutSeconds` maps only to the Amphora data-path idle timeouts:
+
+- `timeout_client_data = idleTimeoutSeconds * 1000`
+- `timeout_member_data = idleTimeoutSeconds * 1000`
+
+The following remain at provider defaults:
+
+- `timeout_member_connect`
+- `timeout_tcp_inspect`
+
+## Controller and Persistence Model
+
+The implementation adds:
+
+- A new user-facing Region CRD: `LoadBalancer`
+- A new OpenStack persistence CRD: `OpenstackLoadBalancer`
+
+`OpenstackLoadBalancer` must persist at minimum:
+
+| Scope | Required fields |
+|---|---|
+| Load balancer | `loadBalancerID`, `vipPortID`, `floatingIPID?` |
+| Listener | `name`, `listenerID`, `poolID`, `healthMonitorID?`, last applied `allowedCidrs`, last applied `idleTimeoutSeconds?`, last applied `proxyProtocolV2` |
+| Member | `instanceId`, `memberID`, last resolved private IP, last resolved port |
+
+Extend the Region provider interfaces with:
+
+- `CreateLoadBalancer`
+- `DeleteLoadBalancer`
+- `UpdateLoadBalancerState`
+
+Provider contract:
+
+- `CreateLoadBalancer` is the idempotent reconcile entrypoint for both create and update.
+- `DeleteLoadBalancer` fully tears down all provider resources, including floating IPs.
+- `UpdateLoadBalancerState` refreshes derived status such as VIP and public IP.
+
+## Reconciliation Semantics
+
+The OpenStack provider implementation must satisfy the following behavior:
+
+- Provider-side reconcile is idempotent across repeated calls.
+- Listener CIDRs are updated in place.
+- Listener idle timeout is updated in place.
+- Member sets and member ports are updated in place.
+- `proxyProtocolV2` changes for TCP listeners are reconciled without changing the public resource contract.
+- Toggling `publicIP` attaches or detaches the Neutron floating IP from the VIP port.
+- Removed members release their permanent references on the corresponding compute instances.
+- Region subscribes to compute-instance lifecycle events and re-reads the affected instance from the Compute API before reconciling.
+- A compute instance private IP change updates the corresponding Octavia member in place.
+- A referenced compute instance with no private IP leaves the load balancer present but non-ready until the IP is available or the member is removed.
+
+## Public Status Exposure
+
+The Region API exposes only provider-agnostic status fields:
+
+- `status.regionId`
+- `status.networkId`
+- `status.vipAddress`
+- `status.publicIP`
+- Standard `status.conditions`
+
+The following are not exposed in v1:
+
+- Octavia IDs
+- Per-listener operating status
+- Per-member health
+- Statistics
+- The status tree
+- The selected algorithm
+- The driver name
+
+## Explicitly Out of Scope
+
+This provider mapping does not include:
+
+- Raw IP-address members
+- OVN compatibility
+- HTTP or HTTPS listeners
+- Terminated TLS
+- L7 routing or policies
+- Weighted members
+- Backup members
+- Session persistence
+- Alternate monitor IP
+- Alternate monitor port
+- HTTP, HTTPS, TLS-HELLO, PING, or SCTP health checks
+- Advanced Amphora timeout knobs beyond `idleTimeoutSeconds`
+- IPv6 VIPs
+- IPv6 members
+- Mixed IPv4 and IPv6 members
+- Additional VIPs
+- Listener connection limits
+
+## Acceptance Criteria
+
+Implementation handoff must include tests that cover:
+
+- Create a private TCP load balancer with one or more compute-instance members.
+- Create a private UDP load balancer with one or more compute-instance members.
+- Create a public load balancer with `publicIP=true`.
+- Create one load balancer with multiple listeners and different `allowedCidrs` per listener.
+- Create a TCP listener with `proxyProtocolV2=true`.
+- Reject `proxyProtocolV2` on UDP listeners.
+- Create a load balancer with no `healthCheck`.
+- Create a load balancer with `healthCheck: {}`.
+- Create a TCP listener with explicit health-check values.
+- Create a UDP listener with explicit health-check values.
+- Create a TCP listener with `idleTimeoutSeconds`.
+- Reject `idleTimeoutSeconds` on UDP listeners.
+- Update listener CIDRs in place.
+- Update listener idle timeout in place.
+- Update member sets and member ports in place.
+- Update `proxyProtocolV2` in place for TCP listeners.
+- Update `publicIP` in place.
+- Reject duplicate listener names.
+- Reject duplicate `(protocol, port)` listeners.
+- Reject invalid CIDRs.
+- Reject wrong-scope compute-instance references.
+- Reject duplicate `instanceId` members.
+- Reject duplicate resolved `(privateIP, port)` backends.
+- Verify network deletion is blocked while the load balancer exists.
+- Verify referenced compute-instance deletion is blocked while referenced.
+- Verify backend members are reconciled when a compute private IP changes.
+- Verify a member whose instance is not yet assigned a private IP keeps the load balancer in a non-ready state.
+- Verify Amphora Octavia resources, floating IPs, and references are fully cleaned up on delete.

--- a/specifications/providers/openstack/load-balancers.md
+++ b/specifications/providers/openstack/load-balancers.md
@@ -8,10 +8,7 @@ The initial provider assumption is Octavia with the Amphora driver. This is an i
 
 | Version | Date | Notes |
 |---|---|---|
-| v0.4 | 2026-04-12 | Compliance review: finalizer lifecycle, downstream error classification, deadlock detection, ErrYield queue semantics, reconciliation recovery, observability, expanded acceptance criteria |
-| v0.3 | 2026-04-11 | Members use IP addresses directly; removed compute-instance lifecycle reconciliation; `Available=True` requires `status.vipAddress` populated |
-| v0.2 | 2026-04-10 | Review update: listener-name identity, dependency-triggered deletion, stale-member withdrawal, and clarified status mapping |
-| v0.1 | 2026-04-10 | Initial draft |
+| v0.1 | 2026-04-13 | Initial version |
 
 ## Scope and Assumptions
 

--- a/specifications/providers/openstack/load-balancers.md
+++ b/specifications/providers/openstack/load-balancers.md
@@ -8,6 +8,7 @@ The initial provider assumption is Octavia with the Amphora driver. This is an i
 
 | Version | Date | Notes |
 |---|---|---|
+| v0.4 | 2026-04-12 | Compliance review: finalizer lifecycle, downstream error classification, deadlock detection, ErrYield queue semantics, reconciliation recovery, observability, expanded acceptance criteria |
 | v0.3 | 2026-04-11 | Members use IP addresses directly; removed compute-instance lifecycle reconciliation; `Available=True` requires `status.vipAddress` populated |
 | v0.2 | 2026-04-10 | Review update: listener-name identity, dependency-triggered deletion, stale-member withdrawal, and clarified status mapping |
 | v0.1 | 2026-04-10 | Initial draft |
@@ -85,6 +86,8 @@ Extend the Region provider interfaces with:
 - `DeleteLoadBalancer`
 - `UpdateLoadBalancerState`
 
+These are in-process Go interfaces called directly by the controller within the Region service. They do not cross an API boundary and require no authentication classification or OpenAPI annotation.
+
 Provider contract:
 
 - `CreateLoadBalancer` is the idempotent reconcile entrypoint for both create and update.
@@ -95,7 +98,7 @@ Provider contract:
 
 The OpenStack provider implementation must satisfy the following behavior:
 
-- Provider-side reconcile is idempotent across repeated calls.
+- Provider-side reconcile is idempotent across repeated calls. If the controller crashes mid-reconcile, the next reconcile pass reads persisted IDs from `OpenstackLoadBalancer` and resumes from the last successful state. Partial provider state is handled by the subsequent reconcile pass without manual intervention.
 - Listener reconciliation is keyed by stable public `listener.name`.
 - A listener rename is handled as delete-and-create of the provider listener and pool subtree.
 - Listener CIDRs are updated in place.
@@ -129,13 +132,59 @@ The following are not exposed in v1:
 
 For status derivation, an effective backend is a member that has been successfully provisioned as an Octavia pool member.
 
-| Octavia or local state | Region condition mapping |
+Every reconcile pass, successful or not, must update the `Available` condition before returning. This is unconditional per [SPECIFICATION.md §8.4](../../SPECIFICATION.md).
+
+| Octavia or local state | Region condition mapping | Reconcile return | Queue behavior |
+|---|---|---|---|
+| `PENDING_CREATE` or `PENDING_UPDATE` | `Available=False` with reason `ConditionReasonProvisioning` | `ErrYield` | Fixed interval requeue |
+| `PENDING_DELETE` or local delete flow | `Available=False` with reason `ConditionReasonDeprovisioning` | `ErrYield` | Fixed interval requeue |
+| `ACTIVE` with at least one effective backend and `status.vipAddress` populated | `Available=True` with reason `ConditionReasonProvisioned` | `nil` | Removed from queue |
+| `ERROR` | `Available=False` with reason `ConditionReasonErrored` | error | Exponential backoff |
+| Zero members or zero effective backends | `Available=False` with reason `ConditionReasonProvisioning` | `ErrYield` | Fixed interval requeue |
+
+The zero-members case uses `ConditionReasonProvisioning` because the load balancer is not yet fully operational, even though the Octavia LB itself may be `ACTIVE` with a VIP allocated. This is the best-fit standard reason within the platform's condition vocabulary. Callers should not interpret `ConditionReasonProvisioning` as necessarily meaning infrastructure provisioning is in progress.
+
+If the status write itself fails (e.g., resource version conflict), the controller requeues with a fixed timeout and does not return an error (status write failure is transient per [SPECIFICATION.md §8.4](../../SPECIFICATION.md)).
+
+## Finalizer Lifecycle
+
+The controller adds its finalizer to the `LoadBalancer` resource before performing any provisioning work per [SPECIFICATION.md §8.5](../../SPECIFICATION.md).
+
+On deletion:
+
+1. The controller detects the deletion timestamp on the `LoadBalancer` resource.
+2. While inbound references or owned children exist, the controller retries silently (`ErrYield`).
+3. The controller calls `DeleteLoadBalancer`, which fully tears down all Octavia resources (listeners, pools, members, health monitors, the load balancer itself), detaches and deletes any Neutron floating IP, and clears the `OpenstackLoadBalancer` persistence state.
+4. The controller releases any outbound references (none in the current design, since the Network edge is a dependency, not a consumption).
+5. Only after all provider resources and references are cleaned up does the controller remove the finalizer.
+
+## Downstream Error Handling
+
+When the controller receives error responses from Octavia or Neutron API calls, it classifies them per [SPECIFICATION.md §8.7](../../SPECIFICATION.md):
+
+| Octavia/Neutron response | Treatment |
 |---|---|
-| `PENDING_CREATE` or `PENDING_UPDATE` | `Available=False` with reason `ConditionReasonProvisioning` |
-| `PENDING_DELETE` or local delete flow | `Available=False` with reason `ConditionReasonDeprovisioning` |
-| `ACTIVE` with at least one effective backend and `status.vipAddress` populated | `Available=True` with reason `ConditionReasonProvisioned` |
-| `ERROR` | `Available=False` with reason `ConditionReasonErrored` |
-| Zero members or zero effective backends | `Available=False` with reason `ConditionReasonProvisioning` |
+| 5xx or service unavailable | Transient. Return `ErrYield`, retry at fixed interval. |
+| 409 conflict (e.g., Octavia `IMMUTABLE`) | Transient. Re-read provider state and retry at fixed interval. |
+| 404 on a resource the controller expects to exist | Genuine error. Surface as `ConditionReasonErrored`. Data inconsistency that will not resolve on retry. |
+| 403 | Genuine error. Surface as `ConditionReasonErrored`. Permission failure will not resolve without intervention. |
+| 401 | Transient for a bounded number of retries (credential refresh). If persistent, surface as `ConditionReasonErrored`. |
+
+The controller must not poll Octavia to check whether dependent resources are ready. Dependency readiness is inferred from local status conditions via status propagation upward per [SPECIFICATION.md §8.7](../../SPECIFICATION.md).
+
+## Deadlock Detection
+
+On every reconcile pass of a load balancer in `DELETING` state, the controller checks the age of the deletion timestamp. If the timestamp has been set for longer than 10 minutes and inbound references are still present, the controller emits a structured zap error log entry per [SPECIFICATION.md §8.8](../../SPECIFICATION.md).
+
+The log entry must include as discrete structured zap fields (indexable in Loki): resource type (`LoadBalancer`), resource ID, deletion timestamp, elapsed duration, and the full set of blocking reference strings.
+
+## Observability
+
+The controller follows the platform observability requirements in [SPECIFICATION.md §9](../../SPECIFICATION.md):
+
+- **Structured logging**: every reconcile pass, state transition (Octavia state changes, floating IP attach/detach), reference operation, and requeue decision is logged with resource type and resource ID as structured zap fields. Verbose controller logging per [SPECIFICATION.md §9.1](../../SPECIFICATION.md).
+- **Distributed tracing**: a span is created for every controller reconcile pass. Outbound calls to Octavia and Neutron propagate trace context.
+- **Metrics**: the controller emits reconcile duration (histogram), reconcile outcome (counter by success/transient/error), work queue depth (gauge), and reference operation count (counter by add/remove and outcome). Metric names follow Prometheus conventions: `snake_case`, service-prefixed, with unit suffixes.
 
 ## Explicitly Out of Scope
 
@@ -193,3 +242,9 @@ Implementation handoff must include tests that cover:
 - Verify network deletion triggers load balancer deletion and is not blocked by the load balancer.
 - Verify member address and port updates are reconciled to Octavia in place.
 - Verify Amphora Octavia resources, floating IPs, and references are fully cleaned up on delete.
+- Verify `PUT` returns `409 conflict` when the resource version has advanced (conflict detection).
+- Verify `DELETE` on an already-deleting resource returns `202` without re-triggering deletion (idempotent delete).
+- Reject load balancer creation when the network is in a different organisational scope (co-location validation returns `422`).
+- Verify the controller finalizer prevents premature garbage collection during deprovisioning.
+- Verify RBAC enforcement for the `region:loadbalancers:v2` scope on all endpoints.
+- Verify behavior when `region.features.loadBalancers` is `false` for the target region.

--- a/specifications/providers/openstack/load-balancers.md
+++ b/specifications/providers/openstack/load-balancers.md
@@ -156,7 +156,7 @@ On deletion:
 1. The controller detects the deletion timestamp on the `LoadBalancer` resource.
 2. While inbound references or owned children exist, the controller retries silently (`ErrYield`).
 3. The controller calls `DeleteLoadBalancer`, which fully tears down all Octavia resources (listeners, pools, members, health monitors, the load balancer itself) and detaches and deletes any Neutron floating IP.
-4. The controller releases any outbound references (none in the current design, since the Network edge is a dependency, not a consumption) and releases the committed load balancer quota allocation or any still-active reservation.
+4. The controller releases any outbound references (none in the current design, since the Network edge is a dependency, not a consumption) and releases the committed quota allocations (`loadbalancers` and, if `publicIP=true`, `publicips`) or any still-active reservations.
 5. Only after all provider resources, quota state, and references are cleaned up does the controller remove the finalizer.
 
 ## Downstream Error Handling
@@ -207,8 +207,6 @@ This provider mapping does not include:
 - Mixed IPv4 and IPv6 members
 - Additional VIPs
 - Listener connection limits
-
-Floating-IP/public-IP quota is also out of scope for this document because that quota is shared across resource types, including instances, and must be defined once at the platform level.
 
 ## Acceptance Criteria
 
@@ -261,4 +259,9 @@ Implementation handoff must include tests that cover:
 - Verify the controller finalizer prevents premature garbage collection during deprovisioning.
 - Verify RBAC enforcement for the `region:loadbalancers:v2` scope on all endpoints.
 
-Do not add a load-balancer-only floating-IP/public-VIP quota test in this version. That quota remains a shared platform-level follow-up across instances and load balancers.
+- Create with `publicIP=true` within `publicips` quota — succeeds.
+- Create with `publicIP=true` when `publicips` quota is exhausted — `403 forbidden`.
+- Update `publicIP` from `false` to `true` within `publicips` quota — succeeds.
+- Update `publicIP` from `false` to `true` when `publicips` quota is exhausted — `403 forbidden`.
+- Update `publicIP` from `true` to `false` — releases the `publicips` allocation.
+- Delete with `publicIP=true` — releases both `loadbalancers` and `publicips` allocations.

--- a/specifications/providers/openstack/load-balancers.md
+++ b/specifications/providers/openstack/load-balancers.md
@@ -8,6 +8,7 @@ The initial provider assumption is Octavia with the Amphora driver. This is an i
 
 | Version | Date | Notes |
 |---|---|---|
+| v0.2 | 2026-04-10 | Review update: listener-name identity, dependency-triggered deletion, stale-member withdrawal, and clarified status mapping |
 | v0.1 | 2026-04-10 | Initial draft |
 
 ## Scope and Assumptions
@@ -73,7 +74,9 @@ The implementation adds:
 |---|---|
 | Load balancer | `loadBalancerID`, `vipPortID`, `floatingIPID?` |
 | Listener | `name`, `listenerID`, `poolID`, `healthMonitorID?`, last applied `allowedCidrs`, last applied `idleTimeoutSeconds?`, last applied `proxyProtocolV2` |
-| Member | `instanceId`, `memberID`, last resolved private IP, last resolved port |
+| Member | `listenerName`, `instanceId`, `memberID`, last resolved private IP, last resolved port |
+
+Listener reconciliation is keyed by the public `listener.name`, not by provider-generated IDs alone. Member persistence must be scoped per listener or pool because the same compute instance may appear in multiple pools.
 
 Extend the Region provider interfaces with:
 
@@ -92,15 +95,19 @@ Provider contract:
 The OpenStack provider implementation must satisfy the following behavior:
 
 - Provider-side reconcile is idempotent across repeated calls.
+- Listener reconciliation is keyed by stable public `listener.name`.
+- A listener rename is handled as delete-and-create of the provider listener and pool subtree.
 - Listener CIDRs are updated in place.
 - Listener idle timeout is updated in place.
+- Health monitor create, delete, and parameter updates are reconciled in place.
 - Member sets and member ports are updated in place.
 - `proxyProtocolV2` changes for TCP listeners are reconciled without changing the public resource contract.
 - Toggling `publicIP` attaches or detaches the Neutron floating IP from the VIP port.
-- Removed members release their permanent references on the corresponding compute instances.
 - Region subscribes to compute-instance lifecycle events and re-reads the affected instance from the Compute API before reconciling.
 - A compute instance private IP change updates the corresponding Octavia member in place.
 - A referenced compute instance with no private IP leaves the load balancer present but non-ready until the IP is available or the member is removed.
+- When a member instance enters `DELETING` or disappears, Region immediately withdraws the corresponding Octavia backend member.
+- A stale public spec entry for a deleted or deleting instance must not recreate a withdrawn backend on later reconciles.
 
 ## Public Status Exposure
 
@@ -121,6 +128,18 @@ The following are not exposed in v1:
 - The status tree
 - The selected algorithm
 - The driver name
+
+## Condition Mapping
+
+For status derivation, an effective backend is a member that resolves to an in-scope compute instance with a usable private IP and has not been withdrawn because the instance is being deleted or no longer exists.
+
+| Octavia or local state | Region condition mapping |
+|---|---|
+| `PENDING_CREATE` or `PENDING_UPDATE` | `Available=False` with reason `ConditionReasonProvisioning` |
+| `PENDING_DELETE` or local delete flow | `Available=False` with reason `ConditionReasonDeprovisioning` |
+| `ACTIVE` with at least one effective backend | `Available=True` with reason `ConditionReasonProvisioned` |
+| `ERROR` | `Available=False` with reason `ConditionReasonErrored` |
+| Zero effective backends, unresolved members, or only stale deleted members | `Available=False` with reason `ConditionReasonProvisioning` |
 
 ## Explicitly Out of Scope
 
@@ -151,6 +170,8 @@ Implementation handoff must include tests that cover:
 - Create a private TCP load balancer with one or more compute-instance members.
 - Create a private UDP load balancer with one or more compute-instance members.
 - Create a public load balancer with `publicIP=true`.
+- Create a load balancer with `members: []` and verify VIP allocation succeeds while `Available` stays false until a backend becomes effective.
+- Create a load balancer before compute instances have private IPs and verify it stays non-ready until the IPs resolve.
 - Create one load balancer with multiple listeners and different `allowedCidrs` per listener.
 - Create a TCP listener with `proxyProtocolV2=true`.
 - Reject `proxyProtocolV2` on UDP listeners.
@@ -161,18 +182,24 @@ Implementation handoff must include tests that cover:
 - Create a TCP listener with `idleTimeoutSeconds`.
 - Reject `idleTimeoutSeconds` on UDP listeners.
 - Update listener CIDRs in place.
+- Verify `allowedCidrs: []` and omitted `allowedCidrs` both mean unrestricted after update.
 - Update listener idle timeout in place.
+- Update a listener by name and verify rename is treated as delete-and-create.
 - Update member sets and member ports in place.
+- Create, remove, and update a health monitor in place.
 - Update `proxyProtocolV2` in place for TCP listeners.
 - Update `publicIP` in place.
 - Reject duplicate listener names.
 - Reject duplicate `(protocol, port)` listeners.
 - Reject invalid CIDRs.
 - Reject wrong-scope compute-instance references.
-- Reject duplicate `instanceId` members.
+- Reject duplicate `instanceId` members within one pool.
+- Allow the same compute instance in different pools on different ports.
 - Reject duplicate resolved `(privateIP, port)` backends.
-- Verify network deletion is blocked while the load balancer exists.
-- Verify referenced compute-instance deletion is blocked while referenced.
+- Verify network deletion triggers load balancer deletion and is not blocked by the load balancer.
+- Verify compute-instance deletion is not blocked by load balancer membership and the provider backend is withdrawn immediately.
+- Verify an unrelated load-balancer update succeeds while unchanged stale deleted members remain in `spec`.
+- Verify adding a new unresolved or wrong-scope member still fails with `422`.
 - Verify backend members are reconciled when a compute private IP changes.
 - Verify a member whose instance is not yet assigned a private IP keeps the load balancer in a non-ready state.
 - Verify Amphora Octavia resources, floating IPs, and references are fully cleaned up on delete.

--- a/specifications/providers/openstack/load-balancers.md
+++ b/specifications/providers/openstack/load-balancers.md
@@ -24,6 +24,8 @@ Terminated TLS remains out of scope so Kubernetes and CCM-managed workloads reta
 
 Regions that expose this API are assumed to provide Octavia with the Amphora driver. Unsupported regions are out of scope for this version rather than modeled as a discoverable feature flag.
 
+This version assumes Octavia load balancer create supports `vip_address` together with `vip_network_id`, and that VIP mutation is not supported as part of load balancer update.
+
 OVN compatibility is explicitly out of scope for this version, since OVN does not support VLANs currently.
 
 ## Resource Mapping
@@ -36,11 +38,13 @@ The public abstraction maps to Octavia and Neutron as follows:
 | One Region listener | One Octavia listener |
 | One Region pool | One Octavia pool |
 | One Region member | One Octavia member using the specified member address and configured member port |
+| `networkId` | Octavia load balancer `vip_network_id` and backend member reachability |
+| `vipAddress` on create | Octavia load balancer create `vip_address` |
 | `publicIP=true` | One Neutron floating IP attached to the VIP port |
 | Listener `allowedCidrs` | Octavia listener allowed-CIDRs feature (`allowed_cidrs` API field) |
 | Hidden public algorithm | Octavia `ROUND_ROBIN` |
 
-`networkId` is the tenant network used for both the VIP subnet selection and backend member reachability.
+`networkId` is the tenant network used for both VIP subnet selection and backend member reachability. When `spec.vipAddress` is set, the provider still derives only `vip_network_id` from `networkId`; this change does not add a public or internal `subnetId` requirement. `publicIP=true` remains compatible with `vipAddress`: the floating IP attaches to the VIP port of the requested internal VIP once that VIP is allocated.
 
 ## Protocol and Health-Monitor Mapping
 
@@ -81,8 +85,10 @@ Provider contract:
 - `CreateLoadBalancer` is the idempotent reconcile entrypoint for both create and update.
 - `DeleteLoadBalancer` fully tears down all provider resources, including floating IPs.
 - `UpdateLoadBalancerState` refreshes derived status such as VIP and public IP.
+- The Region-owned load balancer model may persist a distinct immutable `requestedVipAddress` field. This is internal Region state, not a provider-owned persistence object or public API field.
+- The in-process provider model passed to `CreateLoadBalancer` includes `requestedVipAddress` when set so reconcile remains idempotent across retries and restarts.
 
-No provider-specific persistence CRD or stored "last applied" snapshot is used. Reconcile rediscovers provider resources from live Octavia and Neutron state on every pass.
+No provider-specific persistence CRD or stored "last applied" snapshot is used. Reconcile rediscovers provider resources from live Octavia and Neutron state on every pass, using the Region-owned immutable `requestedVipAddress` as part of desired input when present.
 
 Live discovery uses deterministic names and identities:
 
@@ -99,6 +105,8 @@ The OpenStack provider implementation must satisfy the following behavior:
 
 - Provider-side reconcile is idempotent across repeated calls and controller restarts. Every reconcile pass discovers the live Octavia and Neutron objects for the load balancer by deterministic name or identity and resumes from the observed provider state.
 - Desired state is always diffed against live Octavia and Neutron state, never against stored "last applied" state.
+- When a stored `requestedVipAddress` is present, load balancer creation must pass it to Octavia as `vip_address` together with the existing `vip_network_id` derived from `networkId`.
+- If `requestedVipAddress` is present, reconcile must either allocate that exact VIP or surface a genuine error. It must never accept or allocate a different private VIP as fallback.
 - Listener reconciliation is keyed by stable public `listener.name`.
 - A listener rename is handled as delete-and-create of the provider listener and pool subtree.
 - Changing a listener's `protocol` or `port` while keeping the same `listener.name` is reconciled as an in-place Octavia listener update, not as delete-and-create.
@@ -107,6 +115,8 @@ The OpenStack provider implementation must satisfy the following behavior:
 - Health monitor create, delete, and parameter updates are reconciled in place.
 - Member sets and member ports are updated in place.
 - `proxyProtocolV2` changes for TCP listeners are reconciled without changing the public resource contract.
+- Updates to listeners or `publicIP` preserve the existing VIP. Reconcile does not attempt VIP mutation on update.
+- If live provider state is rediscovered with a VIP different from stored `requestedVipAddress`, the provider treats this as permanent drift and surfaces `ConditionReasonErrored` rather than silently accepting or recreating.
 - Toggling `publicIP` attaches or detaches the Neutron floating IP from the VIP port discovered for the load balancer VIP.
 
 ## Public Status Exposure
@@ -118,6 +128,8 @@ The Region API exposes only provider-agnostic status fields:
 - `status.vipAddress`
 - `status.publicIP`
 - Standard `status.conditions`
+
+There is no public or status `requestedVipAddress` field. `status.vipAddress` continues to report only the actual allocated VIP.
 
 The following are not exposed in v1:
 
@@ -139,11 +151,14 @@ Every reconcile pass, successful or not, must update the `Available` condition b
 |---|---|---|---|
 | `PENDING_CREATE` or `PENDING_UPDATE` | `Available=False` with reason `ConditionReasonProvisioning` | `ErrYield` | Fixed interval requeue |
 | `PENDING_DELETE` or local delete flow | `Available=False` with reason `ConditionReasonDeprovisioning` | `ErrYield` | Fixed interval requeue |
-| `ACTIVE` with at least one effective backend and `status.vipAddress` populated | `Available=True` with reason `ConditionReasonProvisioned` | `nil` | Removed from queue |
+| `ACTIVE` with at least one effective backend, `status.vipAddress` populated, and either no stored `requestedVipAddress` or `status.vipAddress == requestedVipAddress` | `Available=True` with reason `ConditionReasonProvisioned` | `nil` | Removed from queue |
+| `ACTIVE` with stored `requestedVipAddress` but a different live VIP | `Available=False` with reason `ConditionReasonErrored` | error | Exponential backoff |
 | `ERROR` | `Available=False` with reason `ConditionReasonErrored` | error | Exponential backoff |
 | Zero members or zero effective backends | `Available=False` with reason `ConditionReasonProvisioning` | `ErrYield` | Fixed interval requeue |
 
 The zero-members case uses `ConditionReasonProvisioning` because the load balancer is not yet fully operational, even though the Octavia LB itself may be `ACTIVE` with a VIP allocated. This is the best-fit standard reason within the platform's condition vocabulary. Callers should not interpret `ConditionReasonProvisioning` as necessarily meaning infrastructure provisioning is in progress.
+
+When a requested VIP is configured, `status.vipAddress` remains empty until Octavia reports that exact address as the live VIP. A provider rejection of the requested VIP is surfaced as `ConditionReasonErrored`; the implementation must not fall back to a different private VIP.
 
 If the status write itself fails (e.g., resource version conflict), the controller requeues with a fixed timeout and does not return an error (status write failure is transient per [SPECIFICATION.md §8.4](../../../SPECIFICATION.md)).
 
@@ -166,7 +181,8 @@ When the controller receives error responses from Octavia or Neutron API calls, 
 | Octavia/Neutron response | Treatment |
 |---|---|
 | 5xx or service unavailable | Transient. Return `ErrYield`, retry at fixed interval. |
-| 409 conflict (e.g., Octavia `IMMUTABLE`) | Transient. Re-read provider state and retry at fixed interval. |
+| 400 or 409 while satisfying a requested `vip_address` (for example off-network, validation failure, or permanent address-allocation conflict) | Genuine error. Surface as `ConditionReasonErrored`. A requested VIP that cannot be satisfied must not fall back to another private VIP. |
+| 409 conflict unrelated to a requested VIP (for example Octavia `IMMUTABLE`) | Transient. Re-read provider state and retry at fixed interval. |
 | 404 on a resource the controller expects to exist | Genuine error. Surface as `ConditionReasonErrored`. Data inconsistency that will not resolve on retry. |
 | 403 | Genuine error. Surface as `ConditionReasonErrored`. Permission failure will not resolve without intervention. |
 | 401 | Transient for a bounded number of retries (credential refresh). If persistent, surface as `ConditionReasonErrored`. |
@@ -206,6 +222,8 @@ This provider mapping does not include:
 - IPv6 members
 - Mixed IPv4 and IPv6 members
 - Additional VIPs
+- VIP mutation after create
+- Public or internal `subnetId` selection for VIP placement
 - Listener connection limits
 
 ## Acceptance Criteria
@@ -215,9 +233,12 @@ Implementation handoff must include tests that cover:
 - List by `tag` and verify the filter matches the public API representation of tags at `metadata.tags`.
 - Verify the load balancer public API does not expose a load-balancer-specific `spec.tags` field.
 - Verify any backing Region CRD persistence of tags is treated as internal and does not affect API semantics.
+- Create without `vipAddress` and verify behavior is unchanged from provider auto-allocation today.
 - Create a private TCP load balancer with one or more IP-address members.
 - Create a private UDP load balancer with one or more IP-address members.
+- Create a private load balancer with a valid `vipAddress` and verify `status.vipAddress` equals the requested value.
 - Create a public load balancer with `publicIP=true`.
+- Create a public load balancer with `publicIP=true` and a valid `vipAddress`, and verify the requested internal VIP is preserved and the floating IP attaches to it.
 - Create within the load balancer quota and verify success.
 - Reject create over the load balancer quota with `403 forbidden`.
 - Delete a load balancer and verify the load balancer quota allocation is released.
@@ -241,19 +262,25 @@ Implementation handoff must include tests that cover:
 - Create, remove, and update a health monitor in place.
 - Update `proxyProtocolV2` in place for TCP listeners.
 - Update `publicIP` in place.
+- Verify updates to listeners and `publicIP` do not change a successfully allocated requested VIP.
 - Reject duplicate listener names.
 - Reject duplicate `(protocol, port)` listeners.
 - Reject invalid CIDRs.
+- Reject malformed `vipAddress` with `400 invalid_request`.
 - Reject a member with an invalid IPv4 address.
 - Reject duplicate `(address, port)` members within one pool.
 - Allow the same address in different pools.
 - Allow the same address with different ports in one pool.
+- Submit a create with a syntactically valid but unusable requested VIP and verify `Available=False` with `ConditionReasonErrored` and no fallback VIP allocation.
 - Verify network deletion triggers load balancer deletion and is not blocked by the load balancer.
 - Verify network deletion while the load balancer controller is down still causes load balancer deletion after restart and reconcile.
 - Verify member address and port updates are reconciled to Octavia in place.
-- Restart the controller after a partial reconcile and verify existing Octavia resources are rediscovered without any provider persistence object.
+- Restart the controller after a partial reconcile and verify existing Octavia resources are rediscovered without any provider persistence object, and that a stored requested VIP is replayed idempotently.
+- Verify live-provider rediscovery does not silently accept drift where the live VIP differs from the stored requested value.
 - Verify Amphora Octavia resources, floating IPs, and references are fully cleaned up on delete.
+- Verify delete cleanup is unchanged for load balancers with and without a requested VIP.
 - Verify `PUT` returns `409 conflict` when the resource version has advanced (conflict detection).
+- Verify `PUT` containing `vipAddress` is rejected with `400 invalid_request`.
 - Verify `DELETE` on an already-deleting resource returns `202` without re-triggering deletion (idempotent delete).
 - Reject load balancer creation when the network is in a different organisational scope (co-location validation returns `422`).
 - Verify the controller finalizer prevents premature garbage collection during deprovisioning.

--- a/specifications/providers/openstack/load-balancers.md
+++ b/specifications/providers/openstack/load-balancers.md
@@ -109,7 +109,7 @@ The OpenStack provider implementation must satisfy the following behavior:
 - If `requestedVipAddress` is present, reconcile must either allocate that exact VIP or surface a genuine error. It must never accept or allocate a different private VIP as fallback.
 - Listener reconciliation is keyed by stable public `listener.name`.
 - A listener rename is handled as delete-and-create of the provider listener and pool subtree.
-- Changing a listener's `protocol` or `port` while keeping the same `listener.name` is reconciled as an in-place Octavia listener update, not as delete-and-create.
+- Listener `protocol` and `port` are immutable after create (enforced at the public API layer). The provider does not need to handle in-place mutation of either field. Octavia does not support updating `protocol` or `protocol_port` on an existing listener.
 - Listener CIDRs are updated in place.
 - Listener idle timeout is updated in place.
 - Health monitor create, delete, and parameter updates are reconciled in place.
@@ -155,6 +155,7 @@ Every reconcile pass, successful or not, must update the `Available` condition b
 | `ACTIVE` with stored `requestedVipAddress` but a different live VIP | `Available=False` with reason `ConditionReasonErrored` | error | Exponential backoff |
 | `ERROR` | `Available=False` with reason `ConditionReasonErrored` | error | Exponential backoff |
 | Zero members or zero effective backends | `Available=False` with reason `ConditionReasonProvisioning` | `ErrYield` | Fixed interval requeue |
+| Network dependency unavailable or deleted | `Available=False` with reason `ConditionReasonErrored`; controller initiates load balancer deletion if Network has deletion timestamp | Per Network Dependency rules in region spec | Per Network Dependency rules in region spec |
 
 The zero-members case uses `ConditionReasonProvisioning` because the load balancer is not yet fully operational, even though the Octavia LB itself may be `ACTIVE` with a VIP allocated. This is the best-fit standard reason within the platform's condition vocabulary. Callers should not interpret `ConditionReasonProvisioning` as necessarily meaning infrastructure provisioning is in progress.
 
@@ -187,7 +188,7 @@ When the controller receives error responses from Octavia or Neutron API calls, 
 | 403 | Genuine error. Surface as `ConditionReasonErrored`. Permission failure will not resolve without intervention. |
 | 401 | Transient for a bounded number of retries (credential refresh). If persistent, surface as `ConditionReasonErrored`. |
 
-The controller must not poll Octavia to check whether dependent resources are ready. Dependency readiness is inferred from local status conditions via status propagation upward per [SPECIFICATION.md §8.7](../../../SPECIFICATION.md).
+The controller must not poll Octavia to check whether dependent resources are ready. Reconcile rediscovers provider resources from live state on every pass (see Reconciliation Semantics above) and infers dependency readiness from local status conditions via status propagation upward per [SPECIFICATION.md §5.8](../../../SPECIFICATION.md).
 
 ## Deadlock Detection
 
@@ -250,13 +251,14 @@ Implementation handoff must include tests that cover:
 - Create a load balancer with `healthCheck: {}`.
 - Create a TCP listener with explicit health-check values.
 - Create a UDP listener with explicit health-check values.
+- Reject a health check where `timeoutSeconds >= intervalSeconds` with `422 unprocessable_content`.
 - Create a TCP listener with `idleTimeoutSeconds`.
 - Reject `idleTimeoutSeconds` on UDP listeners.
 - Update listener CIDRs in place.
 - Verify `allowedCidrs: []` and omitted `allowedCidrs` both mean unrestricted after update.
 - Update listener idle timeout in place.
-- Update a listener's `protocol` in place while keeping the same name.
-- Update a listener's `port` in place while keeping the same name.
+- Reject updating a listener's `protocol` while keeping the same name with `422 unprocessable_content`.
+- Reject updating a listener's `port` while keeping the same name with `422 unprocessable_content`.
 - Update a listener by name and verify rename is treated as delete-and-create.
 - Update member sets and member ports in place.
 - Create, remove, and update a health monitor in place.

--- a/specifications/providers/openstack/load-balancers.md
+++ b/specifications/providers/openstack/load-balancers.md
@@ -8,6 +8,7 @@ The initial provider assumption is Octavia with the Amphora driver. This is an i
 
 | Version | Date | Notes |
 |---|---|---|
+| v0.3 | 2026-04-11 | Members use IP addresses directly; removed compute-instance lifecycle reconciliation |
 | v0.2 | 2026-04-10 | Review update: listener-name identity, dependency-triggered deletion, stale-member withdrawal, and clarified status mapping |
 | v0.1 | 2026-04-10 | Initial draft |
 
@@ -32,7 +33,7 @@ The public abstraction maps to Octavia and Neutron as follows:
 | One Region load balancer | One Octavia load balancer |
 | One Region listener | One Octavia listener |
 | One Region pool | One Octavia pool |
-| One Region member | One Octavia member using the resolved compute private IP and configured member port |
+| One Region member | One Octavia member using the specified member address and configured member port |
 | `publicIP=true` | One Neutron floating IP attached to the VIP port |
 | Listener `allowedCidrs` | Octavia listener allowed-CIDRs feature (`allowed_cidrs` API field) |
 | Hidden public algorithm | Octavia `ROUND_ROBIN` |
@@ -74,9 +75,9 @@ The implementation adds:
 |---|---|
 | Load balancer | `loadBalancerID`, `vipPortID`, `floatingIPID?` |
 | Listener | `name`, `listenerID`, `poolID`, `healthMonitorID?`, last applied `allowedCidrs`, last applied `idleTimeoutSeconds?`, last applied `proxyProtocolV2` |
-| Member | `listenerName`, `instanceId`, `memberID`, last resolved private IP, last resolved port |
+| Member | `listenerName`, `address`, `memberID`, `port` |
 
-Listener reconciliation is keyed by the public `listener.name`, not by provider-generated IDs alone. Member persistence must be scoped per listener or pool because the same compute instance may appear in multiple pools.
+Listener reconciliation is keyed by the public `listener.name`, not by provider-generated IDs alone. Member persistence must be scoped per listener or pool because the same address may appear in multiple pools with different ports.
 
 Extend the Region provider interfaces with:
 
@@ -103,11 +104,6 @@ The OpenStack provider implementation must satisfy the following behavior:
 - Member sets and member ports are updated in place.
 - `proxyProtocolV2` changes for TCP listeners are reconciled without changing the public resource contract.
 - Toggling `publicIP` attaches or detaches the Neutron floating IP from the VIP port.
-- Region subscribes to compute-instance lifecycle events and re-reads the affected instance from the Compute API before reconciling.
-- A compute instance private IP change updates the corresponding Octavia member in place.
-- A referenced compute instance with no private IP leaves the load balancer present but non-ready until the IP is available or the member is removed.
-- When a member instance enters `DELETING` or disappears, Region immediately withdraws the corresponding Octavia backend member.
-- A stale public spec entry for a deleted or deleting instance must not recreate a withdrawn backend on later reconciles.
 
 ## Public Status Exposure
 
@@ -131,7 +127,7 @@ The following are not exposed in v1:
 
 ## Condition Mapping
 
-For status derivation, an effective backend is a member that resolves to an in-scope compute instance with a usable private IP and has not been withdrawn because the instance is being deleted or no longer exists.
+For status derivation, an effective backend is a member that has been successfully provisioned as an Octavia pool member.
 
 | Octavia or local state | Region condition mapping |
 |---|---|
@@ -139,13 +135,12 @@ For status derivation, an effective backend is a member that resolves to an in-s
 | `PENDING_DELETE` or local delete flow | `Available=False` with reason `ConditionReasonDeprovisioning` |
 | `ACTIVE` with at least one effective backend | `Available=True` with reason `ConditionReasonProvisioned` |
 | `ERROR` | `Available=False` with reason `ConditionReasonErrored` |
-| Zero effective backends, unresolved members, or only stale deleted members | `Available=False` with reason `ConditionReasonProvisioning` |
+| Zero members or zero effective backends | `Available=False` with reason `ConditionReasonProvisioning` |
 
 ## Explicitly Out of Scope
 
 This provider mapping does not include:
 
-- Raw IP-address members
 - OVN compatibility
 - HTTP or HTTPS listeners
 - Terminated TLS
@@ -167,11 +162,10 @@ This provider mapping does not include:
 
 Implementation handoff must include tests that cover:
 
-- Create a private TCP load balancer with one or more compute-instance members.
-- Create a private UDP load balancer with one or more compute-instance members.
+- Create a private TCP load balancer with one or more IP-address members.
+- Create a private UDP load balancer with one or more IP-address members.
 - Create a public load balancer with `publicIP=true`.
 - Create a load balancer with `members: []` and verify VIP allocation succeeds while `Available` stays false until a backend becomes effective.
-- Create a load balancer before compute instances have private IPs and verify it stays non-ready until the IPs resolve.
 - Create one load balancer with multiple listeners and different `allowedCidrs` per listener.
 - Create a TCP listener with `proxyProtocolV2=true`.
 - Reject `proxyProtocolV2` on UDP listeners.
@@ -192,14 +186,10 @@ Implementation handoff must include tests that cover:
 - Reject duplicate listener names.
 - Reject duplicate `(protocol, port)` listeners.
 - Reject invalid CIDRs.
-- Reject wrong-scope compute-instance references.
-- Reject duplicate `instanceId` members within one pool.
-- Allow the same compute instance in different pools on different ports.
-- Reject duplicate resolved `(privateIP, port)` backends.
+- Reject a member with an invalid IPv4 address.
+- Reject duplicate `(address, port)` members within one pool.
+- Allow the same address in different pools.
+- Allow the same address with different ports in one pool.
 - Verify network deletion triggers load balancer deletion and is not blocked by the load balancer.
-- Verify compute-instance deletion is not blocked by load balancer membership and the provider backend is withdrawn immediately.
-- Verify an unrelated load-balancer update succeeds while unchanged stale deleted members remain in `spec`.
-- Verify adding a new unresolved or wrong-scope member still fails with `422`.
-- Verify backend members are reconciled when a compute private IP changes.
-- Verify a member whose instance is not yet assigned a private IP keeps the load balancer in a non-ready state.
+- Verify member address and port updates are reconciled to Octavia in place.
 - Verify Amphora Octavia resources, floating IPs, and references are fully cleaned up on delete.

--- a/specifications/providers/openstack/load-balancers.md
+++ b/specifications/providers/openstack/load-balancers.md
@@ -8,6 +8,7 @@ The initial provider assumption is Octavia with the Amphora driver. This is an i
 
 | Version | Date | Notes |
 |---|---|---|
+| v0.2 | 2026-04-15 | Align delete flow with owner-driven network cascade and keep network health as status-only input. |
 | v0.1 | 2026-04-13 | Initial version |
 
 ## Scope and Assumptions
@@ -118,6 +119,8 @@ The OpenStack provider implementation must satisfy the following behavior:
 - Updates to listeners or `publicIP` preserve the existing VIP. Reconcile does not attempt VIP mutation on update.
 - If live provider state is rediscovered with a VIP different from stored `requestedVipAddress`, the provider treats this as permanent drift and surfaces `ConditionReasonErrored` rather than silently accepting or recreating.
 - Toggling `publicIP` attaches or detaches the Neutron floating IP from the VIP port discovered for the load balancer VIP.
+- Network deletion reaches this provider delete path only after Kubernetes has already tombstoned the Region `LoadBalancer` via owner-driven cascade from the owning `Network`. The provider implementation does not initiate deletion from a `Network` deletion timestamp.
+- If the `LoadBalancer` already has a deletion timestamp, a missing or deleting `Network` is expected during cascaded deletion and must not be treated as a separate dependency-triggered error path.
 
 ## Public Status Exposure
 
@@ -155,9 +158,11 @@ Every reconcile pass, successful or not, must update the `Available` condition b
 | `ACTIVE` with stored `requestedVipAddress` but a different live VIP | `Available=False` with reason `ConditionReasonErrored` | error | Exponential backoff |
 | `ERROR` | `Available=False` with reason `ConditionReasonErrored` | error | Exponential backoff |
 | Zero members or zero effective backends | `Available=False` with reason `ConditionReasonProvisioning` | `ErrYield` | Fixed interval requeue |
-| Network dependency unavailable or deleted | `Available=False` with reason `ConditionReasonErrored`; controller initiates load balancer deletion if Network has deletion timestamp | Per Network Dependency rules in region spec | Per Network Dependency rules in region spec |
+| Network unavailable while the `LoadBalancer` is not deleting | `Available=False` with reason `ConditionReasonErrored` | `nil` | Removed from queue |
 
 The zero-members case uses `ConditionReasonProvisioning` because the load balancer is not yet fully operational, even though the Octavia LB itself may be `ACTIVE` with a VIP allocated. This is the best-fit standard reason within the platform's condition vocabulary. Callers should not interpret `ConditionReasonProvisioning` as necessarily meaning infrastructure provisioning is in progress.
+Octavia `ACTIVE` alone is insufficient for `Available=True` when the observed `Network` is unhealthy.
+When the `LoadBalancer` already has a deletion timestamp, a missing or deleting `Network` is expected during owner-driven cascade and is handled by the `PENDING_DELETE or local delete flow` row above, not as a separate dependency-triggered deletion rule.
 
 When a requested VIP is configured, `status.vipAddress` remains empty until Octavia reports that exact address as the live VIP. A provider rejection of the requested VIP is surfaced as `ConditionReasonErrored`; the implementation must not fall back to a different private VIP.
 
@@ -167,13 +172,15 @@ If the status write itself fails (e.g., resource version conflict), the controll
 
 The controller adds its finalizer to the `LoadBalancer` resource before performing any provisioning work per [SPECIFICATION.md §8.5](../../../SPECIFICATION.md).
 
+In a cascaded network delete, Kubernetes sets the `LoadBalancer` deletion timestamp via owner-driven foreground cascade before provider teardown begins.
+
 On deletion:
 
 1. The controller detects the deletion timestamp on the `LoadBalancer` resource.
 2. While inbound references or owned children exist, the controller retries silently (`ErrYield`).
 3. The controller calls `DeleteLoadBalancer`, which fully tears down all Octavia resources (listeners, pools, members, health monitors, the load balancer itself) and detaches and deletes any Neutron floating IP.
-4. The controller releases any outbound references (none in the current design, since the Network edge is a dependency, not a consumption) and releases the committed quota allocations (`loadbalancers` and, if `publicIP=true`, `publicips`) or any still-active reservations.
-5. Only after all provider resources, quota state, and references are cleaned up does the controller remove the finalizer.
+4. The controller releases the committed quota allocations (`loadbalancers` and, if `publicIP=true`, `publicips`) or any still-active reservations. There is no long-lived outbound reference hold on the `Network` in steady state.
+5. Only after all provider resources, quota state, and any other references owned by the `LoadBalancer` are cleaned up does the controller remove the finalizer.
 
 ## Downstream Error Handling
 
@@ -188,7 +195,7 @@ When the controller receives error responses from Octavia or Neutron API calls, 
 | 403 | Genuine error. Surface as `ConditionReasonErrored`. Permission failure will not resolve without intervention. |
 | 401 | Transient for a bounded number of retries (credential refresh). If persistent, surface as `ConditionReasonErrored`. |
 
-The controller must not poll Octavia to check whether dependent resources are ready. Reconcile rediscovers provider resources from live state on every pass (see Reconciliation Semantics above) and infers dependency readiness from local status conditions via status propagation upward per [SPECIFICATION.md §5.8](../../../SPECIFICATION.md).
+The controller must not poll Octavia to check whether prerequisite resources are ready. Reconcile rediscovers provider resources from live state on every pass (see Reconciliation Semantics above) and infers network health from local status conditions via status propagation upward per [SPECIFICATION.md §5.8](../../../SPECIFICATION.md).
 
 ## Deadlock Detection
 
@@ -274,13 +281,20 @@ Implementation handoff must include tests that cover:
 - Allow the same address in different pools.
 - Allow the same address with different ports in one pool.
 - Submit a create with a syntactically valid but unusable requested VIP and verify `Available=False` with `ConditionReasonErrored` and no fallback VIP allocation.
-- Verify network deletion triggers load balancer deletion and is not blocked by the load balancer.
-- Verify network deletion while the load balancer controller is down still causes load balancer deletion after restart and reconcile.
+- Verify network deletion foreground-cascades to the load balancer via the owner relationship.
+- Verify the network remains in deletion until the load balancer finalizer completes provider cleanup.
+- Verify a network-deleted, already-tombstoned load balancer resumes deprovisioning after controller restart without relying on a missed network deletion watch event.
+- Verify network unavailability without deletion drives `Available=False`.
+- Verify Octavia `ACTIVE` alone is insufficient for `Available=True` when the network is unhealthy.
 - Verify member address and port updates are reconciled to Octavia in place.
 - Restart the controller after a partial reconcile and verify existing Octavia resources are rediscovered without any provider persistence object, and that a stored requested VIP is replayed idempotently.
 - Verify live-provider rediscovery does not silently accept drift where the live VIP differs from the stored requested value.
-- Verify Amphora Octavia resources, floating IPs, and references are fully cleaned up on delete.
-- Verify delete cleanup is unchanged for load balancers with and without a requested VIP.
+- Verify Amphora Octavia resources and floating IPs are fully cleaned up during direct load balancer delete.
+- Verify Amphora Octavia resources and floating IPs are fully cleaned up during cascaded load balancer delete.
+- Verify quota release is unchanged for direct delete and cascaded delete.
+- Verify no long-lived Network reference API hold exists during steady-state load balancer lifetime.
+- Verify deletion behavior is identical for load balancers with and without `publicIP`.
+- Verify deletion behavior is identical for load balancers with and without a requested `vipAddress`.
 - Verify `PUT` returns `409 conflict` when the resource version has advanced (conflict detection).
 - Verify `PUT` containing `vipAddress` is rejected with `400 invalid_request`.
 - Verify `DELETE` on an already-deleting resource returns `202` without re-triggering deletion (idempotent delete).

--- a/specifications/region/load-balancers.md
+++ b/specifications/region/load-balancers.md
@@ -18,6 +18,7 @@ The first public abstraction is intentionally narrow:
 - Listener protocols limited to `tcp` and `udp`
 - Listener-scoped `allowedCidrs`
 - Top-level `publicIP`
+- Optional create-time selection of the primary internal VIP
 - Backend members specified by IPv4 address
 - Per-member backend port
 - Optional transport-level health checks only
@@ -38,8 +39,7 @@ The following are explicitly not part of v1:
 - IPv6 VIPs or members
 - Mixed IPv4 and IPv6 members
 - Additional VIPs
-- User-specified VIP addresses
-- Kubernetes `spec.loadBalancerIP`-style workflows
+- VIP changes after create
 - Listener connection limits
 
 Terminated TLS is intentionally excluded in v1 so Kubernetes and CCM-managed workloads retain end-to-end TLS and, where used, client-certificate visibility at the workload. Regions that expose this API are assumed to provide Octavia/Amphora support; unsupported regions are out of scope rather than modeled as a discoverable per-region capability flag.
@@ -112,6 +112,7 @@ The standard Region v2 envelope applies. This section defines the `spec` and `st
 | `projectId` | yes | Owning project. Immutable after create. |
 | `regionId` | yes | Target region. Immutable after create. |
 | `networkId` | yes | Tenant network used for the VIP subnet and backend member resolution. Immutable after create. |
+| `vipAddress` | no | Requested primary internal IPv4 VIP on the load balancer tenant network. Omit to preserve current provider auto-allocation behavior. |
 | `publicIP` | no | When `true`, request a public IPv4 address for the VIP. |
 | `listeners` | yes | Listener definitions. |
 
@@ -132,18 +133,21 @@ The standard Region v2 envelope applies. This section defines the `spec` and `st
 |---|---|---|
 | `regionId` | yes | Region the load balancer is running in. |
 | `networkId` | yes | Tenant network backing the VIP and member reachability. |
-| `vipAddress` | no | VIP address allocated for the load balancer. |
+| `vipAddress` | no | Actual VIP address allocated for the load balancer. |
 | `publicIP` | no | Public IPv4 address attached to the VIP when enabled. |
 | `conditions` | yes | Standard platform `status.conditions`. |
 
 Rules:
 
 - `organizationId`, `projectId`, `regionId`, and `networkId` are immutable after create.
+- `vipAddress` is optional on create. When omitted, the provider allocates the private VIP exactly as it does today.
+- `vipAddress` is create-only. Because it is absent from `LoadBalancerV2Spec`, `PUT` cannot create, change, or clear the requested VIP.
 - `publicIP` is mutable.
 - `networkId` is the required backend network. All member addresses must be reachable on this network.
 - `spec.publicIP` requests a public VIP address and `status.publicIP` reports the allocated public IPv4. This intentionally matches the existing instance API naming convention.
+- `status.vipAddress` reports the actual allocated VIP for the load balancer.
+- If create succeeds with `spec.vipAddress` set, `status.vipAddress` must equal the requested value.
 - `status.vipAddress` is stable for the lifetime of the load balancer. Once allocated, the VIP does not change.
-- There is no `vipAddress` request field in create or update. Callers cannot request a specific VIP or private address in v1, so Kubernetes `spec.loadBalancerIP`-style workflows are unsupported.
 - `Available=True` must not be reported until `status.vipAddress` is populated.
 - The public status surface is provider-agnostic. Provider IDs, per-listener operating status, per-member health, statistics, the algorithm, the status tree, and driver names are not exposed in v1.
 
@@ -242,11 +246,13 @@ Health-check rules:
 
 ## Validation and Error Semantics
 
-The request body is first validated against the OpenAPI schema. Schema or field-format failures should return `400 invalid_request`. Cross-field or cross-resource semantic failures should return `422 unprocessable_content`.
+The request body is first validated against the OpenAPI schema. Schema or field-format failures, including malformed `vipAddress`, should return `400 invalid_request`. Cross-field or cross-resource semantic failures should return `422 unprocessable_content`.
 
 Create and update validation must enforce all of the following:
 
 - `organizationId`, `projectId`, `regionId`, and `networkId` remain immutable after create.
+- `vipAddress`, when present in `LoadBalancerV2CreateSpec`, must be a valid IPv4 address.
+- `vipAddress` must not be accepted on `PUT`. Because `LoadBalancerV2Spec` excludes the field, any `PUT` body containing `vipAddress` is schema-invalid and returns `400 invalid_request`.
 - The referenced `networkId` must share the same organisational scope root as the load balancer (co-location constraint per [SPECIFICATION.md §5.10](../../SPECIFICATION.md)). Reject with `422 unprocessable_content` if not.
 - Listener names satisfy the documented format and uniqueness rules.
 - Listener ports and member ports are integers in the range `1..65535`.
@@ -262,17 +268,22 @@ Create and update validation must enforce all of the following:
 - Duplicate `(address, port)` members in the same pool are rejected.
 - Member addresses are not validated for reachability at submission time. Network-layer reachability is the caller's responsibility.
 
+If `vipAddress` is set, reconcile must either allocate that exact VIP or fail the resource. It must never substitute a different private VIP when a specific internal VIP was requested.
+
+Because writes are asynchronous, a create request with a syntactically valid but unusable `vipAddress` still returns `202 Accepted` if it passes request-time validation. If allocation later fails because the requested address is off-network, already in use, unavailable, or otherwise rejected by the provider, reconcile sets `Available=False` with reason `ConditionReasonErrored`. `status.vipAddress` remains empty until the exact requested VIP is actually allocated.
+
 Update operations use optimistic locking via `MergeFromWithOptimisticLock` per [SPECIFICATION.md §7.3](../../SPECIFICATION.md). If the resource version has advanced since the client last read the resource, the write is rejected with `409 conflict`.
 
 Preferred response behavior:
 
 | Condition | Preferred response |
 |---|---|
-| Invalid IPv4 CIDR syntax in `allowedCidrs`, invalid listener name format, invalid member `address`, or out-of-range numeric field values | `400 invalid_request` |
+| Invalid `vipAddress` syntax, invalid IPv4 CIDR syntax in `allowedCidrs`, invalid listener name format, invalid member `address`, or out-of-range numeric field values | `400 invalid_request` |
 | Authentication failure or expired token | `401 access_denied` |
 | Authenticated principal lacks permission, or quota exhausted | `403 forbidden` |
 | Resource not found on GET, PUT, or DELETE | `404 not_found` |
 | Write conflict on PUT (resource version advanced) | `409 conflict` |
+| `vipAddress` present in a `PUT` body | `400 invalid_request` |
 | Unsupported field combinations such as `proxyProtocolV2=true` on `udp` or `idleTimeoutSeconds` on `udp` | `422 unprocessable_content` |
 | Co-location constraint violation (`networkId` not in same organisational scope) | `422 unprocessable_content` |
 | `timeoutSeconds >= intervalSeconds` | `422 unprocessable_content` |
@@ -283,7 +294,7 @@ All error responses follow the standard platform error body format (`error`, `er
 
 ## Quota Semantics
 
-Per [SPECIFICATION.md §7.6](../../SPECIFICATION.md), v1 requires quota enforcement for both load balancer count and public IP allocation. The quota kind for public IPs is `publicips`, which is a shared quota defined in `uni-identity` (default: 5) and consumed by all services that allocate public IPs (compute instances, load balancers, etc.).
+Per [SPECIFICATION.md §7.6](../../SPECIFICATION.md), v1 requires quota enforcement for both load balancer count and public IP allocation. The quota kind for public IPs is `publicips`, which is a shared quota defined in `uni-identity` (default: 5) and consumed by all services that allocate public IPs (compute instances, load balancers, etc.). Requested internal VIPs do not introduce a new quota kind and do not change existing `loadbalancers` or `publicips` accounting.
 
 - **Create**: the saga reserves `1` `loadbalancers` quota unit keyed by the load balancer resource UUID. If `spec.publicIP=true`, the saga also reserves `1` `publicips` unit keyed by the same UUID. If either quota is exhausted, the handler returns `403 forbidden`.
 - Successful provisioning promotes both reservations to committed allocations.
@@ -320,14 +331,14 @@ This is an intra-service edge (both resources are owned by the Region service). 
 
 ### Owned Resources
 
-[SPECIFICATION.md §2.1](../../SPECIFICATION.md) must be updated to include `LoadBalancer` in the Region service's owned resources table.
+[SPECIFICATION.md §2.1](../../SPECIFICATION.md) includes `LoadBalancer` in the Region service's owned resources table.
 
 ## Handler Semantics
 
 The standard Region v2 handler layer responsibilities ([SPECIFICATION.md §7.2](../../SPECIFICATION.md)) apply. Load-balancer-specific notes:
 
-- **Create**: the handler derives labels and annotations via `conversion.NewObjectMetadata`. Labels and annotations are never accepted from the request body. The handler uses a saga with soft reservation steps for `1` `loadbalancers` quota unit and, when `spec.publicIP=true`, `1` `publicips` quota unit per [SPECIFICATION.md §7.5, §7.6](../../SPECIFICATION.md), then creates the `LoadBalancer` CRD as the terminal write. If either quota is exhausted, it returns `403 forbidden`.
-- **Update**: the handler reads the current resource, re-derives labels and annotations, and patches with optimistic locking via `MergeFromWithOptimisticLock`. A concurrent modification returns `409 conflict`. If `publicIP` toggles from `false` to `true`, the handler checks `publicips` quota and returns `403 forbidden` if exhausted, then updates the allocation to add the `publicips` unit. If `publicIP` toggles from `true` to `false`, the handler updates the allocation to remove the `publicips` unit.
+- **Create**: the handler derives labels and annotations via `conversion.NewObjectMetadata`. Labels and annotations are never accepted from the request body. The handler uses a saga with soft reservation steps for `1` `loadbalancers` quota unit and, when `spec.publicIP=true`, `1` `publicips` quota unit per [SPECIFICATION.md §7.5, §7.6](../../SPECIFICATION.md), then creates the `LoadBalancer` CRD as the terminal write. If `spec.vipAddress` is present, the handler persists it as a distinct immutable internal field (for example `requestedVipAddress`) on the backing resource so reconcile can replay the same provider request idempotently across retries and restarts. If either quota is exhausted, it returns `403 forbidden`.
+- **Update**: the handler reads the current resource, re-derives labels and annotations, and patches with optimistic locking via `MergeFromWithOptimisticLock`. A concurrent modification returns `409 conflict`. `vipAddress` is intentionally absent from `LoadBalancerV2Spec`; any `PUT` body containing it fails schema validation with `400 invalid_request`. If `publicIP` toggles from `false` to `true`, the handler checks `publicips` quota and returns `403 forbidden` if exhausted, then updates the allocation to add the `publicips` unit. If `publicIP` toggles from `true` to `false`, the handler updates the allocation to remove the `publicips` unit.
 - **Delete**: the handler verifies `DeletionTimestamp` is nil before issuing the delete. If already set, it returns `202` idempotently.
 
 All POST, PUT, and DELETE operations emit audit log entries per [SPECIFICATION.md §9.2](../../SPECIFICATION.md).
@@ -356,6 +367,8 @@ The load balancer API handlers and controller follow the platform observability 
 The initial public behavior is:
 
 - `publicIP` is top-level on the load balancer spec.
+- Omitted `vipAddress` preserves current provider auto-allocation behavior for the primary internal VIP.
+- `vipAddress`, when supplied on create, selects only the primary internal VIP and remains immutable after create.
 - `allowedCidrs` is listener-scoped.
 - `proxyProtocolV2` is v2-only, TCP-only, and defaults to `false`.
 - `healthCheck` object presence means enabled.

--- a/specifications/region/load-balancers.md
+++ b/specifications/region/load-balancers.md
@@ -8,6 +8,7 @@ The standard Region v2 resource envelope and the platform-wide rules in [SPECIFI
 
 | Version | Date | Notes |
 |---|---|---|
+| v0.4 | 2026-04-12 | Compliance review: formal edge property declaration, authentication classification, conflict detection, co-location validation, finalizer lifecycle, handler semantics, observability, open questions |
 | v0.3 | 2026-04-11 | Members specified by IP address instead of compute-instance reference; Compute-Member Lifecycle cross-service dependency removed; VIP stability and `Available` precondition guarantees added |
 | v0.2 | 2026-04-10 | Review update: empty member sets, dependency-triggered deletion, stale-member tolerance, and clarified validation/status semantics |
 | v0.1 | 2026-04-10 | Initial draft |
@@ -43,6 +44,7 @@ The following are explicitly not part of v1:
 - User-specified VIP addresses
 - Kubernetes `spec.loadBalancerIP`-style workflows
 - Listener connection limits
+- Quota enforcement (deferred; must be addressed before GA per [SPECIFICATION.md §7.6](../../SPECIFICATION.md))
 
 ## API Surface
 
@@ -54,7 +56,9 @@ Add the following Region v2 endpoints:
 - `PUT /api/v2/loadbalancers/{loadBalancerID}`
 - `DELETE /api/v2/loadbalancers/{loadBalancerID}`
 
-All write operations are asynchronous and return `202 Accepted`. Callers must poll `GET /api/v2/loadbalancers/{loadBalancerID}` and read `status.conditions` to determine whether provisioning or deletion has completed. There is no `GET /api/v2/loadbalancers/{loadBalancerID}/status`.
+All endpoints are **Public** (OAuth2 bearer token, no OpenAPI extension required). RBAC is enforced against the derived user principal per [SPECIFICATION.md §7.2.1](../../SPECIFICATION.md).
+
+All write operations are asynchronous and return `202 Accepted`. Callers must poll `GET /api/v2/loadbalancers/{loadBalancerID}` and read `status.conditions` to determine whether provisioning or deletion has completed. There is no `GET /api/v2/loadbalancers/{loadBalancerID}/status`. `DELETE` on a resource that already has a deletion timestamp set returns `202` without re-triggering deletion.
 
 List filters follow existing Region v2 conventions:
 
@@ -65,6 +69,8 @@ List filters follow existing Region v2 conventions:
 - `tag`
 
 The `tag` filter applies generic resource metadata tags inherited from the standard Region v2 envelope. This document does not add a load-balancer-specific `tags` field under `spec`.
+
+List results are sorted stably by name for deterministic ordering per [SPECIFICATION.md §7.8](../../SPECIFICATION.md).
 
 RBAC adds the new scope:
 
@@ -164,6 +170,7 @@ Listener rules:
 
 - `name` is the stable reconciliation identity for the listener.
 - Renaming a listener is treated as delete-and-create, not an in-place rename.
+- Changing a listener's `protocol` or `port` while keeping the same `name` is an in-place update. The `(protocol, port)` uniqueness constraint is validated against the full submitted listener set, not the previous state.
 - `name` must be 1 to 63 characters, use only ASCII alphanumerics and `-`, start with an alphanumeric, end with an alphanumeric, and be unique within the load balancer.
 - `(protocol, port)` must be unique within the load balancer.
 - `port` must be an integer in the range `1..65535`.
@@ -171,7 +178,7 @@ Listener rules:
 - Omitted or empty `allowedCidrs` means unrestricted ingress for that listener on both create and update.
 - Every `allowedCidrs` entry must be a valid IPv4 CIDR.
 - `idleTimeoutSeconds` is valid only for `tcp`.
-- `idleTimeoutSeconds` must be an integer greater than or equal to `1`.
+- `idleTimeoutSeconds` must be an integer in the range `1..86400` (1 second to 24 hours).
 - Omitted `idleTimeoutSeconds` means provider default.
 
 ## Pool Schema
@@ -246,9 +253,10 @@ The request body is first validated against the OpenAPI schema. Schema or field-
 Create and update validation must enforce all of the following:
 
 - `organizationId`, `projectId`, `regionId`, and `networkId` remain immutable after create.
+- The referenced `networkId` must share the same organisational scope root as the load balancer (co-location constraint per [SPECIFICATION.md §5.10](../../SPECIFICATION.md)). Reject with `422 unprocessable_content` if not.
 - Listener names satisfy the documented format and uniqueness rules.
 - Listener ports and member ports are integers in the range `1..65535`.
-- `idleTimeoutSeconds`, when present, is an integer greater than or equal to `1`.
+- `idleTimeoutSeconds`, when present, is an integer in the range `1..86400`.
 - Health-check intervals and timeouts are integers greater than or equal to `1`.
 - Health-check thresholds are integers in the range `1..10`.
 - `proxyProtocolV2=true` is rejected for `udp`.
@@ -260,29 +268,83 @@ Create and update validation must enforce all of the following:
 - Duplicate `(address, port)` members in the same pool are rejected.
 - Member addresses are not validated for reachability at submission time. Network-layer reachability is the caller's responsibility.
 
+Update operations use optimistic locking via `MergeFromWithOptimisticLock` per [SPECIFICATION.md §7.3](../../SPECIFICATION.md). If the resource version has advanced since the client last read the resource, the write is rejected with `409 conflict`.
+
 Preferred response behavior:
 
 | Condition | Preferred response |
 |---|---|
 | Invalid IPv4 CIDR syntax in `allowedCidrs`, invalid listener name format, invalid member `address`, or out-of-range numeric field values | `400 invalid_request` |
+| Authentication failure or expired token | `401 access_denied` |
+| Authenticated principal lacks permission, or quota exhausted | `403 forbidden` |
+| Resource not found on GET, PUT, or DELETE | `404 not_found` |
+| Write conflict on PUT (resource version advanced) | `409 conflict` |
 | Unsupported field combinations such as `proxyProtocolV2=true` on `udp` or `idleTimeoutSeconds` on `udp` | `422 unprocessable_content` |
+| Co-location constraint violation (`networkId` not in same organisational scope) | `422 unprocessable_content` |
 | `timeoutSeconds >= intervalSeconds` | `422 unprocessable_content` |
 | Duplicate listener names, duplicate `(protocol, port)` listeners, or duplicate `(address, port)` members in one pool | `422 unprocessable_content` |
+| Unexpected internal error | `500 server_error` |
 
-## Cross-Service Semantics
+All error responses follow the standard platform error body format (`error`, `error_description`, `trace_id`) per [SPECIFICATION.md §7.9](../../SPECIFICATION.md). The `PUT` endpoint must advertise `409` in the OpenAPI spec per [SPECIFICATION.md §7.3](../../SPECIFICATION.md).
+
+## Resource Graph
+
+### Edge Declarations
+
+Per [SPECIFICATION.md §5.10](../../SPECIFICATION.md), the LoadBalancer resource type declares the following edge:
+
+| Edge | Type | Properties |
+|---|---|---|
+| LoadBalancer → Network | Dependency | Reverse Deletion Propagation (triggering) + Status Propagation Upward + Co-location Required |
+
+This is an intra-service edge (both resources are owned by the Region service). No blocking reference is placed on the Network per the Dependency edge contract ([SPECIFICATION.md §5.7](../../SPECIFICATION.md)).
 
 ### Network Dependency
 
-- `networkId` establishes a dependency edge from the load balancer to the consumed Region `Network`.
-- If the referenced network enters `DELETING`, Region must initiate deletion of the dependent load balancer.
-- The network is not blocked by the load balancer. Deleting the network triggers load balancer deletion instead of being rejected.
+- `networkId` establishes a dependency edge from the load balancer to the Region `Network`.
+- If the referenced network enters `DELETING`, the controller must initiate deletion of the dependent load balancer. The network is not blocked by the load balancer.
+- The controller registers a Kubernetes watch on the Network resource type (intra-service edge per [SPECIFICATION.md §8.6](../../SPECIFICATION.md)) to detect the network's deletion timestamp and trigger load balancer deletion.
+- When the Network's status changes, the controller re-derives the load balancer's status from the aggregate state of connected targets (status propagation upward per [SPECIFICATION.md §5.8](../../SPECIFICATION.md)). If the Network becomes unavailable, the load balancer reflects this in its own conditions.
 
 ### Member Address Semantics
 
-- Members are specified by IPv4 address. There is no cross-service dependency on compute instances.
+- Members are specified by IPv4 address. There is no edge relationship or cross-service dependency on compute instances.
 - The load balancer does not validate member address reachability at submission time.
 - With `healthCheck` enabled, provider health monitoring will detect and remove unreachable backends from rotation.
 - Without `healthCheck`, traffic may be attempted to unreachable backends until the client updates the member list.
+
+### Owned Resources
+
+[SPECIFICATION.md §2.1](../../SPECIFICATION.md) must be updated to include `LoadBalancer` in the Region service's owned resources table.
+
+## Handler Semantics
+
+The standard Region v2 handler layer responsibilities ([SPECIFICATION.md §7.2](../../SPECIFICATION.md)) apply. Load-balancer-specific notes:
+
+- **Create**: the handler derives labels and annotations via `conversion.NewObjectMetadata`. Labels and annotations are never accepted from the request body. The handler creates the `LoadBalancer` CRD as the terminal write. If quota is enforced in a future version, the handler must use a saga with a soft reservation step and compensating transaction per [SPECIFICATION.md §7.5, §7.6](../../SPECIFICATION.md).
+- **Update**: the handler reads the current resource, re-derives labels and annotations, and patches with optimistic locking via `MergeFromWithOptimisticLock`. A concurrent modification returns `409 conflict`.
+- **Delete**: the handler verifies `DeletionTimestamp` is nil before issuing the delete. If already set, it returns `202` idempotently.
+
+All POST, PUT, and DELETE operations emit audit log entries per [SPECIFICATION.md §9.2](../../SPECIFICATION.md).
+
+## Controller Lifecycle
+
+### Finalizer
+
+The controller adds its finalizer to the `LoadBalancer` resource before performing any provisioning work. On deletion, the controller detects the deletion timestamp, retries silently while owned children or references exist, runs full deprovisioning (including all provider resources), and removes the finalizer only after deprovisioning completes per [SPECIFICATION.md §8.5](../../SPECIFICATION.md).
+
+### Deadlock Detection
+
+On every reconcile pass of a load balancer in `DELETING` state, the controller checks the age of the deletion timestamp. If the timestamp exceeds 10 minutes and inbound references are still present, the controller emits a structured zap log entry with: resource type, resource ID, deletion timestamp, elapsed duration, and the full set of blocking reference strings as discrete structured fields per [SPECIFICATION.md §8.8](../../SPECIFICATION.md).
+
+## Observability
+
+The load balancer API handlers and controller follow the platform observability requirements in [SPECIFICATION.md §9](../../SPECIFICATION.md):
+
+- **Structured logging**: the controller logs every reconcile pass, state transition, reference operation, and requeue decision with resource type and resource ID as structured zap fields. API handlers log on non-2xx responses only.
+- **Audit logging**: all authenticated, scoped, state-mutating API operations (POST, PUT, DELETE) emit `msg: audit` entries at info level with the required fields (actor, operation, scope, resource, result).
+- **Distributed tracing**: a span is created for every inbound API request and every controller reconcile pass. The trace ID is included in all non-2xx error responses.
+- **Metrics**: the controller emits reconcile duration (histogram), reconcile outcome (counter), work queue depth (gauge), and reference operation count (counter). API handlers emit request duration (histogram) and request count (counter), both by endpoint and status class.
 
 ## Defaults and Derived Behavior
 
@@ -300,3 +362,10 @@ The initial public behavior is:
 - The implementation is IPv4-only.
 
 Provider-specific protocol, health-monitor, timeout, and persistence mapping is defined in [OpenStack Load Balancers](../providers/openstack/load-balancers.md).
+
+## Open Questions
+
+- Should quota enforcement be included in v1, or is deferral acceptable for initial launch? If deferred, what is the target milestone?
+- Should there be maximum limits on the number of listeners, members per pool, or `allowedCidrs` entries per listener? Octavia may impose its own limits that should be surfaced.
+- When a load balancer has zero members and Octavia reports `ACTIVE` with a VIP, the condition is `ConditionReasonProvisioning`. Should the platform condition vocabulary be extended to distinguish "provisioned but not operational" from "provisioning in progress"?
+- When `region.features.loadBalancers` is `false` for a region, should the endpoints return `404` (region has no LB capability) or `422` (feature not enabled)?

--- a/specifications/region/load-balancers.md
+++ b/specifications/region/load-balancers.md
@@ -41,7 +41,8 @@ The following are explicitly not part of v1:
 - User-specified VIP addresses
 - Kubernetes `spec.loadBalancerIP`-style workflows
 - Listener connection limits
-- Quota enforcement (deferred; must be addressed before GA per [SPECIFICATION.md §7.6](../../SPECIFICATION.md))
+
+Terminated TLS is intentionally excluded in v1 so Kubernetes and CCM-managed workloads retain end-to-end TLS and, where used, client-certificate visibility at the workload. Regions that expose this API are assumed to provide Octavia/Amphora support; unsupported regions are out of scope rather than modeled as a discoverable per-region capability flag.
 
 ## API Surface
 
@@ -65,17 +66,13 @@ List filters follow existing Region v2 conventions:
 - `networkID`
 - `tag`
 
-The `tag` filter applies generic resource metadata tags inherited from the standard Region v2 envelope. This document does not add a load-balancer-specific `tags` field under `spec`.
+The `tag` filter matches the standard user-facing resource tags exposed at `metadata.tags` in the shared UNI resource envelope and is evaluated post-list per [SPECIFICATION.md §7.8](../../SPECIFICATION.md). This document does not add a load-balancer-specific public `tags` field under `spec`. The backing Region CRD may persist tags at `spec.tags` as an internal implementation detail; that does not change the public API contract.
 
 List results are sorted stably by name for deterministic ordering per [SPECIFICATION.md §7.8](../../SPECIFICATION.md).
 
 RBAC adds the new scope:
 
 - `region:loadbalancers:v2`
-
-Provider capability discovery adds:
-
-- `region.features.loadBalancers: bool`
 
 ## Public Types
 
@@ -201,7 +198,7 @@ Pool rules:
 
 ## Member Schema
 
-Members are specified by IPv4 address.
+Members are specified by IPv4 address. This remains IP-only in v1 because Octavia pool membership is directly IP-based, and a server-reference variant would introduce compute-resource deletion semantics that conflict with expected CCM/CAPI scale-down flows.
 
 Each `LoadBalancerMemberV2` contains:
 
@@ -284,6 +281,17 @@ Preferred response behavior:
 
 All error responses follow the standard platform error body format (`error`, `error_description`, `trace_id`) per [SPECIFICATION.md §7.9](../../SPECIFICATION.md). The `PUT` endpoint must advertise `409` in the OpenAPI spec per [SPECIFICATION.md §7.3](../../SPECIFICATION.md).
 
+## Quota Semantics
+
+Per [SPECIFICATION.md §7.6](../../SPECIFICATION.md), v1 requires quota enforcement for load balancer count.
+
+- Create reserves `1` load balancer quota unit keyed by the load balancer resource UUID before returning `202 Accepted`. If quota is exhausted, the handler returns `403 forbidden`.
+- Successful provisioning promotes that reservation to a committed allocation.
+- Update does not change quota consumption. This spec does not quota-track `publicIP`, so toggling it does not consume or release load balancer quota.
+- Delete releases the committed allocation, or any still-active reservation, before the controller removes its finalizer.
+
+Shared floating-IP/public-IP quota is a cross-resource concern spanning instances and load balancers. It must be specified once at the platform level for all consumers and is intentionally not defined in this resource-specific v1 document.
+
 ## Resource Graph
 
 ### Edge Declarations
@@ -300,12 +308,14 @@ This is an intra-service edge (both resources are owned by the Region service). 
 
 - `networkId` establishes a dependency edge from the load balancer to the Region `Network`.
 - If the referenced network enters `DELETING`, the controller must initiate deletion of the dependent load balancer. The network is not blocked by the load balancer.
-- The controller registers a Kubernetes watch on the Network resource type (intra-service edge per [SPECIFICATION.md §8.6](../../SPECIFICATION.md)) to detect the network's deletion timestamp and trigger load balancer deletion.
+- The controller registers a Kubernetes watch on the Network resource type (intra-service edge per [SPECIFICATION.md §8.6](../../SPECIFICATION.md)) as the fast-path trigger for network deletion and status changes.
+- Every load balancer reconcile must also `Get` the referenced Network directly. If the Network is missing or already has a deletion timestamp, the controller must initiate load balancer deletion even if the watch event was missed while the controller was down.
 - When the Network's status changes, the controller re-derives the load balancer's status from the aggregate state of connected targets (status propagation upward per [SPECIFICATION.md §5.8](../../SPECIFICATION.md)). If the Network becomes unavailable, the load balancer reflects this in its own conditions.
 
 ### Member Address Semantics
 
 - Members are specified by IPv4 address. There is no edge relationship or cross-service dependency on compute instances.
+- This aligns the public API with Octavia's native member model and avoids introducing a server-reference abstraction that would incorrectly block instance deletion during CCM-managed or Cluster API scale-down.
 - The load balancer does not validate member address reachability at submission time.
 - With `healthCheck` enabled, provider health monitoring will detect and remove unreachable backends from rotation.
 - Without `healthCheck`, traffic may be attempted to unreachable backends until the client updates the member list.
@@ -318,8 +328,8 @@ This is an intra-service edge (both resources are owned by the Region service). 
 
 The standard Region v2 handler layer responsibilities ([SPECIFICATION.md §7.2](../../SPECIFICATION.md)) apply. Load-balancer-specific notes:
 
-- **Create**: the handler derives labels and annotations via `conversion.NewObjectMetadata`. Labels and annotations are never accepted from the request body. The handler creates the `LoadBalancer` CRD as the terminal write. If quota is enforced in a future version, the handler must use a saga with a soft reservation step and compensating transaction per [SPECIFICATION.md §7.5, §7.6](../../SPECIFICATION.md).
-- **Update**: the handler reads the current resource, re-derives labels and annotations, and patches with optimistic locking via `MergeFromWithOptimisticLock`. A concurrent modification returns `409 conflict`.
+- **Create**: the handler derives labels and annotations via `conversion.NewObjectMetadata`. Labels and annotations are never accepted from the request body. The handler uses a saga with a soft reservation step for `1` load balancer quota unit per [SPECIFICATION.md §7.5, §7.6](../../SPECIFICATION.md), then creates the `LoadBalancer` CRD as the terminal write. If quota is exhausted, it returns `403 forbidden`.
+- **Update**: the handler reads the current resource, re-derives labels and annotations, and patches with optimistic locking via `MergeFromWithOptimisticLock`. A concurrent modification returns `409 conflict`. Updates do not change quota consumption because only load balancer count is quota-tracked here.
 - **Delete**: the handler verifies `DeletionTimestamp` is nil before issuing the delete. If already set, it returns `202` idempotently.
 
 All POST, PUT, and DELETE operations emit audit log entries per [SPECIFICATION.md §9.2](../../SPECIFICATION.md).
@@ -328,7 +338,7 @@ All POST, PUT, and DELETE operations emit audit log entries per [SPECIFICATION.m
 
 ### Finalizer
 
-The controller adds its finalizer to the `LoadBalancer` resource before performing any provisioning work. On deletion, the controller detects the deletion timestamp, retries silently while owned children or references exist, runs full deprovisioning (including all provider resources), and removes the finalizer only after deprovisioning completes per [SPECIFICATION.md §8.5](../../SPECIFICATION.md).
+The controller adds its finalizer to the `LoadBalancer` resource before performing any provisioning work. On deletion, the controller detects the deletion timestamp, retries silently while owned children or references exist, runs full deprovisioning (including all provider resources), releases any committed quota allocation or surviving reservation, and removes the finalizer only after deprovisioning completes per [SPECIFICATION.md §8.5](../../SPECIFICATION.md).
 
 ### Deadlock Detection
 
@@ -358,11 +368,9 @@ The initial public behavior is:
 - Zero members keep the load balancer present but not yet available.
 - The implementation is IPv4-only.
 
-Provider-specific protocol, health-monitor, timeout, and persistence mapping is defined in [OpenStack Load Balancers](../providers/openstack/load-balancers.md).
+Provider-specific protocol, health-monitor, timeout, and live-discovery mapping is defined in [OpenStack Load Balancers](../providers/openstack/load-balancers.md).
 
 ## Open Questions
 
-- Should quota enforcement be included in v1, or is deferral acceptable for initial launch? If deferred, what is the target milestone?
 - Should there be maximum limits on the number of listeners, members per pool, or `allowedCidrs` entries per listener? Octavia may impose its own limits that should be surfaced.
 - When a load balancer has zero members and Octavia reports `ACTIVE` with a VIP, the condition is `ConditionReasonProvisioning`. Should the platform condition vocabulary be extended to distinguish "provisioned but not operational" from "provisioning in progress"?
-- When `region.features.loadBalancers` is `false` for a region, should the endpoints return `404` (region has no LB capability) or `422` (feature not enabled)?

--- a/specifications/region/load-balancers.md
+++ b/specifications/region/load-balancers.md
@@ -8,10 +8,7 @@ The standard Region v2 resource envelope and the platform-wide rules in [SPECIFI
 
 | Version | Date | Notes |
 |---|---|---|
-| v0.4 | 2026-04-12 | Compliance review: formal edge property declaration, authentication classification, conflict detection, co-location validation, finalizer lifecycle, handler semantics, observability, open questions |
-| v0.3 | 2026-04-11 | Members specified by IP address instead of compute-instance reference; Compute-Member Lifecycle cross-service dependency removed; VIP stability and `Available` precondition guarantees added |
-| v0.2 | 2026-04-10 | Review update: empty member sets, dependency-triggered deletion, stale-member tolerance, and clarified validation/status semantics |
-| v0.1 | 2026-04-10 | Initial draft |
+| v0.1 | 2026-04-13 | Initial version |
 
 ## Initial Scope
 

--- a/specifications/region/load-balancers.md
+++ b/specifications/region/load-balancers.md
@@ -8,6 +8,7 @@ The standard Region v2 resource envelope and the platform-wide rules in [SPECIFI
 
 | Version | Date | Notes |
 |---|---|---|
+| v0.3 | 2026-04-11 | Members specified by IP address instead of compute-instance reference; Compute-Member Lifecycle cross-service dependency removed |
 | v0.2 | 2026-04-10 | Review update: empty member sets, dependency-triggered deletion, stale-member tolerance, and clarified validation/status semantics |
 | v0.1 | 2026-04-10 | Initial draft |
 
@@ -19,7 +20,7 @@ The first public abstraction is intentionally narrow:
 - Listener protocols limited to `tcp` and `udp`
 - Listener-scoped `allowedCidrs`
 - Top-level `publicIP`
-- Backend members limited to `uni-compute` instances
+- Backend members specified by IPv4 address
 - Per-member backend port
 - Optional transport-level health checks only
 - Optional TCP-only `proxyProtocolV2`
@@ -28,7 +29,6 @@ The first public abstraction is intentionally narrow:
 
 The following are explicitly not part of v1:
 
-- Raw IP-address members
 - HTTP and HTTPS listeners
 - Terminated TLS
 - L7 routing or policies
@@ -140,7 +140,7 @@ Rules:
 
 - `organizationId`, `projectId`, `regionId`, and `networkId` are immutable after create.
 - `publicIP` is mutable.
-- `networkId` is the required backend network for all referenced compute instances.
+- `networkId` is the required backend network. All member addresses must be reachable on this network.
 - `spec.publicIP` requests a public VIP address and `status.publicIP` reports the allocated public IPv4. This intentionally matches the existing instance API naming convention.
 - There is no `vipAddress` request field in create or update. Callers cannot request a specific VIP or private address in v1, so Kubernetes `spec.loadBalancerIP`-style workflows are unsupported.
 - The public status surface is provider-agnostic. Provider IDs, per-listener operating status, per-member health, statistics, the algorithm, the status tree, and driver names are not exposed in v1.
@@ -189,29 +189,28 @@ Pool rules:
 - Omitted `proxyProtocolV2` defaults to `false`.
 - `proxyProtocolV2=true` means the backend connection is wrapped in PROXY protocol version 2.
 - `members` may be `[]` on create or update.
-- A load balancer with zero effective backends, meaning no member currently resolves to a live in-scope instance with a usable private IP, remains present and still receives a VIP, but does not report `Available=True` until at least one backend becomes effective.
+- A load balancer with zero members remains present and still receives a VIP, but does not report `Available=True` until at least one backend is effective.
 - There is no public `algorithm` field.
 - The implementation fixes the hidden algorithm to `ROUND_ROBIN`.
 
 ## Member Schema
 
-Members are limited to `uni-compute` instances in v1.
+Members are specified by IPv4 address.
 
 Each `LoadBalancerMemberV2` contains:
 
 | Field | Required | Description |
 |---|---|---|
-| `instanceId` | yes | Referenced compute instance. |
+| `address` | yes | IPv4 address of the backend member. |
 | `port` | yes | Backend port used for this member. |
 
 Member rules:
 
-- `instanceId` is required.
+- `address` is required and must be a valid IPv4 address (not a CIDR, not a hostname).
 - `port` is required and must be an integer in the range `1..65535`.
-- Duplicate `instanceId` values in one pool are rejected.
-- The same `instanceId` may appear in different pools if the resulting backends remain distinct.
-- Duplicate resolved `(privateIP, port)` backends are rejected once instance IPs are known.
-- Raw IP-address members are unsupported in v1.
+- Duplicate `(address, port)` pairs in one pool are rejected.
+- The same `address` may appear in different pools if the resulting `(address, port)` backends remain distinct.
+- The same `address` may appear multiple times in one pool with different `port` values.
 
 ## Health Check Schema
 
@@ -255,25 +254,18 @@ Create and update validation must enforce all of the following:
 - `timeoutSeconds` must be less than `intervalSeconds` when a health check is present.
 - Duplicate listener names are rejected.
 - Duplicate `(protocol, port)` listeners are rejected.
-- Duplicate `instanceId` members in the same pool are rejected.
-- Duplicate resolved `(privateIP, port)` backends are rejected.
-- On create, every supplied `instanceId` resolves through the Compute v2 API and belongs to the same organization, project, region, and network as the load balancer.
-- A referenced compute instance may exist before private IP assignment. In that case the load balancer remains provisioning until the address resolves.
-- On update, every newly added or modified member must resolve and belong to the same organization, project, region, and network as the load balancer.
-- On update, unchanged stale members whose instances are now `DELETING` or already gone are tolerated temporarily so clients can perform unrelated updates and then remove or replace them.
+- Every member `address` must be a valid IPv4 address.
+- Duplicate `(address, port)` members in the same pool are rejected.
+- Member addresses are not validated for reachability at submission time. Network-layer reachability is the caller's responsibility.
 
 Preferred response behavior:
 
 | Condition | Preferred response |
 |---|---|
-| Invalid IPv4 CIDR syntax in `allowedCidrs`, invalid listener name format, or out-of-range numeric field values | `400 invalid_request` |
+| Invalid IPv4 CIDR syntax in `allowedCidrs`, invalid listener name format, invalid member `address`, or out-of-range numeric field values | `400 invalid_request` |
 | Unsupported field combinations such as `proxyProtocolV2=true` on `udp` or `idleTimeoutSeconds` on `udp` | `422 unprocessable_content` |
 | `timeoutSeconds >= intervalSeconds` | `422 unprocessable_content` |
-| Duplicate listener names, duplicate `(protocol, port)` listeners, duplicate `instanceId` members in one pool, or duplicate resolved `(privateIP, port)` backends | `422 unprocessable_content` |
-| Newly supplied `instanceId` cannot be resolved to a usable compute instance in the same scope | `422 unprocessable_content` |
-| Resolved compute instance is on a different network | `422 unprocessable_content` |
-
-The validation error for an unusable `instanceId` must be generic. It must not disclose whether the supplied ID was nonexistent, unreadable, or merely outside the caller's scope.
+| Duplicate listener names, duplicate `(protocol, port)` listeners, or duplicate `(address, port)` members in one pool | `422 unprocessable_content` |
 
 ## Cross-Service Semantics
 
@@ -283,29 +275,12 @@ The validation error for an unusable `instanceId` must be generic. It must not d
 - If the referenced network enters `DELETING`, Region must initiate deletion of the dependent load balancer.
 - The network is not blocked by the load balancer. Deleting the network triggers load balancer deletion instead of being rejected.
 
-### Compute-Member Lifecycle
+### Member Address Semantics
 
-- Load balancer membership does not place a permanent blocking reference on member compute instances.
-- Region subscribes to compute-instance lifecycle events through the platform event mechanism.
-- On a compute-instance event, Region re-reads the compute instance through the Compute API and reconciles the affected load balancer.
-- If a referenced instance's private IP changes, backend members are updated in place.
-- If a referenced instance temporarily has no private IP, the load balancer remains present but not ready until the address is available or the member is removed.
-- When a member instance enters `DELETING` or disappears, Region immediately withdraws the corresponding provider backend or member.
-- Region does not mutate the public load-balancer `spec` during that withdrawal path. The stale member entry remains until the client removes or replaces it.
-- A stale member entry that points at a deleted or deleting instance must not cause the backend to be recreated on later reconciles.
-
-### Client Responsibilities
-
-- Cluster API or other infrastructure clients should remove members as part of machine scale-down.
-- Kubernetes CCM integrations should remove members when the corresponding node disappears.
-- Clients must not rely on automatic public-spec cleanup.
-
-### Non-Running Instance Behavior
-
-- Stopped, errored, and rebooting instances are not auto-removed from the member list.
-- With `healthCheck` enabled, provider health monitoring may pull those backends out of rotation.
-- Without `healthCheck`, traffic may continue to be attempted to failed backends until the client updates the member list.
-- This is a v1 limitation.
+- Members are specified by IPv4 address. There is no cross-service dependency on compute instances.
+- The load balancer does not validate member address reachability at submission time.
+- With `healthCheck` enabled, provider health monitoring will detect and remove unreachable backends from rotation.
+- Without `healthCheck`, traffic may be attempted to unreachable backends until the client updates the member list.
 
 ## Defaults and Derived Behavior
 
@@ -319,7 +294,7 @@ The initial public behavior is:
 - `healthCheck: {}` means enabled with defaults.
 - Health-check add, remove, and parameter updates are supported in place.
 - Omitted `idleTimeoutSeconds` uses provider defaults.
-- Zero effective backends, unresolved members, or only stale withdrawn members keep the load balancer present but not yet available.
+- Zero members keep the load balancer present but not yet available.
 - The implementation is IPv4-only.
 
 Provider-specific protocol, health-monitor, timeout, and persistence mapping is defined in [OpenStack Load Balancers](../providers/openstack/load-balancers.md).

--- a/specifications/region/load-balancers.md
+++ b/specifications/region/load-balancers.md
@@ -8,6 +8,7 @@ The standard Region v2 resource envelope and the platform-wide rules in [SPECIFI
 
 | Version | Date | Notes |
 |---|---|---|
+| v0.2 | 2026-04-10 | Review update: empty member sets, dependency-triggered deletion, stale-member tolerance, and clarified validation/status semantics |
 | v0.1 | 2026-04-10 | Initial draft |
 
 ## Initial Scope
@@ -39,8 +40,9 @@ The following are explicitly not part of v1:
 - IPv6 VIPs or members
 - Mixed IPv4 and IPv6 members
 - Additional VIPs
+- User-specified VIP addresses
+- Kubernetes `spec.loadBalancerIP`-style workflows
 - Listener connection limits
-- Raw IP members
 
 ## API Surface
 
@@ -52,7 +54,7 @@ Add the following Region v2 endpoints:
 - `PUT /api/v2/loadbalancers/{loadBalancerID}`
 - `DELETE /api/v2/loadbalancers/{loadBalancerID}`
 
-All write operations are asynchronous and return `202 Accepted`. Callers must read `status.conditions` to determine whether provisioning has completed.
+All write operations are asynchronous and return `202 Accepted`. Callers must poll `GET /api/v2/loadbalancers/{loadBalancerID}` and read `status.conditions` to determine whether provisioning or deletion has completed. There is no `GET /api/v2/loadbalancers/{loadBalancerID}/status`.
 
 List filters follow existing Region v2 conventions:
 
@@ -61,6 +63,8 @@ List filters follow existing Region v2 conventions:
 - `regionID`
 - `networkID`
 - `tag`
+
+The `tag` filter applies generic resource metadata tags inherited from the standard Region v2 envelope. This document does not add a load-balancer-specific `tags` field under `spec`.
 
 RBAC adds the new scope:
 
@@ -137,6 +141,8 @@ Rules:
 - `organizationId`, `projectId`, `regionId`, and `networkId` are immutable after create.
 - `publicIP` is mutable.
 - `networkId` is the required backend network for all referenced compute instances.
+- `spec.publicIP` requests a public VIP address and `status.publicIP` reports the allocated public IPv4. This intentionally matches the existing instance API naming convention.
+- There is no `vipAddress` request field in create or update. Callers cannot request a specific VIP or private address in v1, so Kubernetes `spec.loadBalancerIP`-style workflows are unsupported.
 - The public status surface is provider-agnostic. Provider IDs, per-listener operating status, per-member health, statistics, the algorithm, the status tree, and driver names are not exposed in v1.
 
 ## Listener Schema
@@ -145,7 +151,7 @@ Each listener is represented by `LoadBalancerListenerV2`:
 
 | Field | Required | Description |
 |---|---|---|
-| `name` | yes | Listener name, unique within the load balancer. |
+| `name` | yes | Stable listener identity, unique within the load balancer. |
 | `protocol` | yes | `tcp` or `udp`. |
 | `port` | yes | Frontend port number. |
 | `allowedCidrs` | no | IPv4 CIDRs allowed to reach this listener. |
@@ -154,12 +160,16 @@ Each listener is represented by `LoadBalancerListenerV2`:
 
 Listener rules:
 
-- `name` must be unique within the load balancer.
+- `name` is the stable reconciliation identity for the listener.
+- Renaming a listener is treated as delete-and-create, not an in-place rename.
+- `name` must be 1 to 63 characters, use only ASCII alphanumerics and `-`, start with an alphanumeric, end with an alphanumeric, and be unique within the load balancer.
 - `(protocol, port)` must be unique within the load balancer.
+- `port` must be an integer in the range `1..65535`.
 - `allowedCidrs` uses OR semantics.
-- Omitted or empty `allowedCidrs` means unrestricted ingress for that listener.
+- Omitted or empty `allowedCidrs` means unrestricted ingress for that listener on both create and update.
 - Every `allowedCidrs` entry must be a valid IPv4 CIDR.
 - `idleTimeoutSeconds` is valid only for `tcp`.
+- `idleTimeoutSeconds` must be an integer greater than or equal to `1`.
 - Omitted `idleTimeoutSeconds` means provider default.
 
 ## Pool Schema
@@ -169,14 +179,17 @@ Each listener owns exactly one `LoadBalancerPoolV2`:
 | Field | Required | Description |
 |---|---|---|
 | `proxyProtocolV2` | no | TCP-only backend PROXY protocol version 2 toggle. |
-| `members` | yes | Backend members. |
+| `members` | yes | Backend members. The field is required but may be empty. |
 | `healthCheck` | no | Optional transport-level health check. |
 
 Pool rules:
 
 - Exactly one pool exists per listener.
 - `proxyProtocolV2` is valid only for `tcp` listeners.
+- Omitted `proxyProtocolV2` defaults to `false`.
 - `proxyProtocolV2=true` means the backend connection is wrapped in PROXY protocol version 2.
+- `members` may be `[]` on create or update.
+- A load balancer with zero effective backends, meaning no member currently resolves to a live in-scope instance with a usable private IP, remains present and still receives a VIP, but does not report `Available=True` until at least one backend becomes effective.
 - There is no public `algorithm` field.
 - The implementation fixes the hidden algorithm to `ROUND_ROBIN`.
 
@@ -194,8 +207,9 @@ Each `LoadBalancerMemberV2` contains:
 Member rules:
 
 - `instanceId` is required.
-- `port` is required.
+- `port` is required and must be an integer in the range `1..65535`.
 - Duplicate `instanceId` values in one pool are rejected.
+- The same `instanceId` may appear in different pools if the resulting backends remain distinct.
 - Duplicate resolved `(privateIP, port)` backends are rejected once instance IPs are known.
 - Raw IP-address members are unsupported in v1.
 
@@ -218,7 +232,10 @@ Health-check rules:
 - There is no `protocol` field.
 - There is no `port` field.
 - There are no HTTP, HTTPS, TLS, or other L7-specific health-check fields.
+- `intervalSeconds` and `timeoutSeconds` must be integers greater than or equal to `1`.
+- `healthyThreshold` and `unhealthyThreshold` must be integers in the range `1..10`.
 - `timeoutSeconds` must be less than `intervalSeconds` when a health check is present.
+- Health-check add, remove, and parameter updates are supported in place.
 - Health checks always target the member's configured backend port using transport semantics derived from the listener protocol and pool settings.
 
 ## Validation and Error Semantics
@@ -228,46 +245,67 @@ The request body is first validated against the OpenAPI schema. Schema or field-
 Create and update validation must enforce all of the following:
 
 - `organizationId`, `projectId`, `regionId`, and `networkId` remain immutable after create.
-- Every `instanceId` resolves through the Compute v2 API.
-- Every referenced compute instance belongs to the same organization, project, region, and network as the load balancer.
-- Referenced compute instances may exist before private IP assignment. In that case the load balancer remains provisioning until the address resolves.
+- Listener names satisfy the documented format and uniqueness rules.
+- Listener ports and member ports are integers in the range `1..65535`.
+- `idleTimeoutSeconds`, when present, is an integer greater than or equal to `1`.
+- Health-check intervals and timeouts are integers greater than or equal to `1`.
+- Health-check thresholds are integers in the range `1..10`.
 - `proxyProtocolV2=true` is rejected for `udp`.
 - `idleTimeoutSeconds` is rejected for `udp`.
 - `timeoutSeconds` must be less than `intervalSeconds` when a health check is present.
 - Duplicate listener names are rejected.
 - Duplicate `(protocol, port)` listeners are rejected.
-- Duplicate `instanceId` members are rejected.
+- Duplicate `instanceId` members in the same pool are rejected.
 - Duplicate resolved `(privateIP, port)` backends are rejected.
+- On create, every supplied `instanceId` resolves through the Compute v2 API and belongs to the same organization, project, region, and network as the load balancer.
+- A referenced compute instance may exist before private IP assignment. In that case the load balancer remains provisioning until the address resolves.
+- On update, every newly added or modified member must resolve and belong to the same organization, project, region, and network as the load balancer.
+- On update, unchanged stale members whose instances are now `DELETING` or already gone are tolerated temporarily so clients can perform unrelated updates and then remove or replace them.
 
 Preferred response behavior:
 
 | Condition | Preferred response |
 |---|---|
-| Invalid IPv4 CIDR syntax in `allowedCidrs` | `400 invalid_request` |
+| Invalid IPv4 CIDR syntax in `allowedCidrs`, invalid listener name format, or out-of-range numeric field values | `400 invalid_request` |
 | Unsupported field combinations such as `proxyProtocolV2=true` on `udp` or `idleTimeoutSeconds` on `udp` | `422 unprocessable_content` |
 | `timeoutSeconds >= intervalSeconds` | `422 unprocessable_content` |
-| Duplicate listener names, duplicate `(protocol, port)` listeners, duplicate `instanceId` members, or duplicate resolved `(privateIP, port)` backends | `422 unprocessable_content` |
-| Supplied `instanceId` cannot be resolved to a usable compute instance in the same scope | `422 unprocessable_content` |
+| Duplicate listener names, duplicate `(protocol, port)` listeners, duplicate `instanceId` members in one pool, or duplicate resolved `(privateIP, port)` backends | `422 unprocessable_content` |
+| Newly supplied `instanceId` cannot be resolved to a usable compute instance in the same scope | `422 unprocessable_content` |
 | Resolved compute instance is on a different network | `422 unprocessable_content` |
 
 The validation error for an unusable `instanceId` must be generic. It must not disclose whether the supplied ID was nonexistent, unreadable, or merely outside the caller's scope.
 
 ## Cross-Service Semantics
 
-The Region load balancer controller maintains permanent references to:
+### Network Dependency
 
-- The consumed Region `Network`
-- Every referenced `uni-compute` compute instance
+- `networkId` establishes a dependency edge from the load balancer to the consumed Region `Network`.
+- If the referenced network enters `DELETING`, Region must initiate deletion of the dependent load balancer.
+- The network is not blocked by the load balancer. Deleting the network triggers load balancer deletion instead of being rejected.
 
-The resource graph semantics are:
+### Compute-Member Lifecycle
 
-- Network deletion is blocked while a load balancer exists.
-- Referenced compute-instance deletion is blocked while it remains a member.
-- References are reconciled on every pass so removed members release references.
+- Load balancer membership does not place a permanent blocking reference on member compute instances.
 - Region subscribes to compute-instance lifecycle events through the platform event mechanism.
 - On a compute-instance event, Region re-reads the compute instance through the Compute API and reconciles the affected load balancer.
 - If a referenced instance's private IP changes, backend members are updated in place.
 - If a referenced instance temporarily has no private IP, the load balancer remains present but not ready until the address is available or the member is removed.
+- When a member instance enters `DELETING` or disappears, Region immediately withdraws the corresponding provider backend or member.
+- Region does not mutate the public load-balancer `spec` during that withdrawal path. The stale member entry remains until the client removes or replaces it.
+- A stale member entry that points at a deleted or deleting instance must not cause the backend to be recreated on later reconciles.
+
+### Client Responsibilities
+
+- Cluster API or other infrastructure clients should remove members as part of machine scale-down.
+- Kubernetes CCM integrations should remove members when the corresponding node disappears.
+- Clients must not rely on automatic public-spec cleanup.
+
+### Non-Running Instance Behavior
+
+- Stopped, errored, and rebooting instances are not auto-removed from the member list.
+- With `healthCheck` enabled, provider health monitoring may pull those backends out of rotation.
+- Without `healthCheck`, traffic may continue to be attempted to failed backends until the client updates the member list.
+- This is a v1 limitation.
 
 ## Defaults and Derived Behavior
 
@@ -275,11 +313,13 @@ The initial public behavior is:
 
 - `publicIP` is top-level on the load balancer spec.
 - `allowedCidrs` is listener-scoped.
-- `proxyProtocolV2` is v2-only and TCP-only.
+- `proxyProtocolV2` is v2-only, TCP-only, and defaults to `false`.
 - `healthCheck` object presence means enabled.
 - Health-check omission means disabled.
 - `healthCheck: {}` means enabled with defaults.
+- Health-check add, remove, and parameter updates are supported in place.
 - Omitted `idleTimeoutSeconds` uses provider defaults.
+- Zero effective backends, unresolved members, or only stale withdrawn members keep the load balancer present but not yet available.
 - The implementation is IPv4-only.
 
 Provider-specific protocol, health-monitor, timeout, and persistence mapping is defined in [OpenStack Load Balancers](../providers/openstack/load-balancers.md).

--- a/specifications/region/load-balancers.md
+++ b/specifications/region/load-balancers.md
@@ -148,7 +148,7 @@ Rules:
 - `status.vipAddress` reports the actual allocated VIP for the load balancer.
 - If create succeeds with `spec.vipAddress` set, `status.vipAddress` must equal the requested value.
 - `status.vipAddress` is stable for the lifetime of the load balancer. Once allocated, the VIP does not change.
-- `Available=True` must not be reported until `status.vipAddress` is populated.
+- `Available=True` must not be reported until all of the following hold: `status.vipAddress` is populated, at least one effective backend exists, and (when `spec.vipAddress` was set on create) `status.vipAddress` equals the requested value.
 - The public status surface is provider-agnostic. Provider IDs, per-listener operating status, per-member health, statistics, the algorithm, the status tree, and driver names are not exposed in v1.
 
 ## Listener Schema
@@ -158,8 +158,8 @@ Each listener is represented by `LoadBalancerListenerV2`:
 | Field | Required | Description |
 |---|---|---|
 | `name` | yes | Stable listener identity, unique within the load balancer. |
-| `protocol` | yes | `tcp` or `udp`. |
-| `port` | yes | Frontend port number. |
+| `protocol` | yes | `tcp` or `udp`. Immutable after create. |
+| `port` | yes | Frontend port number. Immutable after create. |
 | `allowedCidrs` | no | IPv4 CIDRs allowed to reach this listener. |
 | `idleTimeoutSeconds` | no | TCP-only idle timeout override. |
 | `pool` | yes | Exactly one backend pool for this listener. |
@@ -167,8 +167,8 @@ Each listener is represented by `LoadBalancerListenerV2`:
 Listener rules:
 
 - `name` is the stable reconciliation identity for the listener.
+- `protocol` and `port` are immutable after create. On update, the handler must verify that `protocol` and `port` match the existing listener with the same `name`. A mismatch is rejected with `422 unprocessable_content`. To change a listener's protocol or port, remove the listener and add a new one.
 - Renaming a listener is treated as delete-and-create, not an in-place rename.
-- Changing a listener's `protocol` or `port` while keeping the same `name` is an in-place update. The `(protocol, port)` uniqueness constraint is validated against the full submitted listener set, not the previous state.
 - `name` must be 1 to 63 characters, use only ASCII alphanumerics and `-`, start with an alphanumeric, end with an alphanumeric, and be unique within the load balancer.
 - `(protocol, port)` must be unique within the load balancer.
 - `port` must be an integer in the range `1..65535`.
@@ -196,7 +196,7 @@ Pool rules:
 - Omitted `proxyProtocolV2` defaults to `false`.
 - `proxyProtocolV2=true` means the backend connection is wrapped in PROXY protocol version 2.
 - `members` may be `[]` on create or update.
-- A load balancer with zero members remains present and still receives a VIP, but does not report `Available=True` until at least one backend is effective.
+- A load balancer with zero members remains present and still receives a VIP. See Status rules for `Available` preconditions.
 - There is no public `algorithm` field.
 - The implementation fixes the hidden algorithm to `ROUND_ROBIN`.
 
@@ -238,7 +238,7 @@ Health-check rules:
 - There is no `protocol` field.
 - There is no `port` field.
 - There are no HTTP, HTTPS, TLS, or other L7-specific health-check fields.
-- `intervalSeconds` and `timeoutSeconds` must be integers greater than or equal to `1`.
+- `intervalSeconds` and `timeoutSeconds` must be integers in the range `1..300`.
 - `healthyThreshold` and `unhealthyThreshold` must be integers in the range `1..10`.
 - `timeoutSeconds` must be less than `intervalSeconds` when a health check is present.
 - Health-check add, remove, and parameter updates are supported in place.
@@ -254,10 +254,11 @@ Create and update validation must enforce all of the following:
 - `vipAddress`, when present in `LoadBalancerV2CreateSpec`, must be a valid IPv4 address.
 - `vipAddress` must not be accepted on `PUT`. Because `LoadBalancerV2Spec` excludes the field, any `PUT` body containing `vipAddress` is schema-invalid and returns `400 invalid_request`.
 - The referenced `networkId` must share the same organisational scope root as the load balancer (co-location constraint per [SPECIFICATION.md §5.10](../../SPECIFICATION.md)). Reject with `422 unprocessable_content` if not.
+- On update, each listener's `protocol` and `port` must match the existing listener with the same `name`. A mismatch is rejected with `422 unprocessable_content`.
 - Listener names satisfy the documented format and uniqueness rules.
 - Listener ports and member ports are integers in the range `1..65535`.
 - `idleTimeoutSeconds`, when present, is an integer in the range `1..86400`.
-- Health-check intervals and timeouts are integers greater than or equal to `1`.
+- Health-check intervals and timeouts are integers in the range `1..300`.
 - Health-check thresholds are integers in the range `1..10`.
 - `proxyProtocolV2=true` is rejected for `udp`.
 - `idleTimeoutSeconds` is rejected for `udp`.
@@ -284,6 +285,7 @@ Preferred response behavior:
 | Resource not found on GET, PUT, or DELETE | `404 not_found` |
 | Write conflict on PUT (resource version advanced) | `409 conflict` |
 | `vipAddress` present in a `PUT` body | `400 invalid_request` |
+| Listener `protocol` or `port` changed on update (mismatch with existing listener of the same `name`) | `422 unprocessable_content` |
 | Unsupported field combinations such as `proxyProtocolV2=true` on `udp` or `idleTimeoutSeconds` on `udp` | `422 unprocessable_content` |
 | Co-location constraint violation (`networkId` not in same organisational scope) | `422 unprocessable_content` |
 | `timeoutSeconds >= intervalSeconds` | `422 unprocessable_content` |
@@ -298,7 +300,7 @@ Per [SPECIFICATION.md §7.6](../../SPECIFICATION.md), v1 requires quota enforcem
 
 - **Create**: the saga reserves `1` `loadbalancers` quota unit keyed by the load balancer resource UUID. If `spec.publicIP=true`, the saga also reserves `1` `publicips` unit keyed by the same UUID. If either quota is exhausted, the handler returns `403 forbidden`.
 - Successful provisioning promotes both reservations to committed allocations.
-- **Update**: if `publicIP` changes from `false` to `true`, the handler updates the allocation to add `1` `publicips` unit (quota check applies; `403 forbidden` if exhausted). If `publicIP` changes from `true` to `false`, the handler updates the allocation to remove the `publicips` unit. Changes to `publicIP` do not affect the `loadbalancers` quota.
+- **Update**: if `publicIP` changes from `false` to `true`, the handler reserves `1` `publicips` unit before patching the CRD. If quota is exhausted, the handler returns `403 forbidden` without modifying the resource. The reservation is promoted to a committed allocation by the controller on successful provisioning. If the CRD patch fails (e.g., optimistic lock conflict), the handler releases the reservation as saga compensation. If `publicIP` changes from `true` to `false`, the controller releases the `publicips` unit during deprovisioning of the floating IP. Changes to `publicIP` do not affect the `loadbalancers` quota.
 - **Delete**: releasing the committed allocation covers both `loadbalancers` and `publicips` (whichever was committed) before the controller removes its finalizer.
 
 ## Resource Graph
@@ -338,7 +340,7 @@ This is an intra-service edge (both resources are owned by the Region service). 
 The standard Region v2 handler layer responsibilities ([SPECIFICATION.md §7.2](../../SPECIFICATION.md)) apply. Load-balancer-specific notes:
 
 - **Create**: the handler derives labels and annotations via `conversion.NewObjectMetadata`. Labels and annotations are never accepted from the request body. The handler uses a saga with soft reservation steps for `1` `loadbalancers` quota unit and, when `spec.publicIP=true`, `1` `publicips` quota unit per [SPECIFICATION.md §7.5, §7.6](../../SPECIFICATION.md), then creates the `LoadBalancer` CRD as the terminal write. If `spec.vipAddress` is present, the handler persists it as a distinct immutable internal field (for example `requestedVipAddress`) on the backing resource so reconcile can replay the same provider request idempotently across retries and restarts. If either quota is exhausted, it returns `403 forbidden`.
-- **Update**: the handler reads the current resource, re-derives labels and annotations, and patches with optimistic locking via `MergeFromWithOptimisticLock`. A concurrent modification returns `409 conflict`. `vipAddress` is intentionally absent from `LoadBalancerV2Spec`; any `PUT` body containing it fails schema validation with `400 invalid_request`. If `publicIP` toggles from `false` to `true`, the handler checks `publicips` quota and returns `403 forbidden` if exhausted, then updates the allocation to add the `publicips` unit. If `publicIP` toggles from `true` to `false`, the handler updates the allocation to remove the `publicips` unit.
+- **Update**: the handler reads the current resource, re-derives labels and annotations, and patches with optimistic locking via `MergeFromWithOptimisticLock`. A concurrent modification returns `409 conflict`. `vipAddress` is intentionally absent from `LoadBalancerV2Spec`; any `PUT` body containing it fails schema validation with `400 invalid_request`. If `publicIP` toggles from `false` to `true`, the handler reserves `1` `publicips` unit before patching the CRD and returns `403 forbidden` if exhausted; the reservation is released as compensation if the CRD patch fails. If `publicIP` toggles from `true` to `false`, the `publicips` unit is released by the controller during floating IP deprovisioning.
 - **Delete**: the handler verifies `DeletionTimestamp` is nil before issuing the delete. If already set, it returns `202` idempotently.
 
 All POST, PUT, and DELETE operations emit audit log entries per [SPECIFICATION.md §9.2](../../SPECIFICATION.md).

--- a/specifications/region/load-balancers.md
+++ b/specifications/region/load-balancers.md
@@ -1,0 +1,285 @@
+# Region Load Balancers v2
+
+This document defines the public `uni-region` v2 load balancer API. It is the normative public abstraction for Layer 4 load balancing. Provider-specific mapping for the initial OpenStack Octavia Amphora implementation is documented in [OpenStack Load Balancers](../providers/openstack/load-balancers.md).
+
+The standard Region v2 resource envelope and the platform-wide rules in [SPECIFICATION.md](../../SPECIFICATION.md) still apply. This document defines the load-balancer-specific API surface, schema, validation rules, and cross-service semantics.
+
+## Changelog
+
+| Version | Date | Notes |
+|---|---|---|
+| v0.1 | 2026-04-10 | Initial draft |
+
+## Initial Scope
+
+The first public abstraction is intentionally narrow:
+
+- Layer 4 only
+- Listener protocols limited to `tcp` and `udp`
+- Listener-scoped `allowedCidrs`
+- Top-level `publicIP`
+- Backend members limited to `uni-compute` instances
+- Per-member backend port
+- Optional transport-level health checks only
+- Optional TCP-only `proxyProtocolV2`
+- A single TCP idle-timeout control
+- IPv4 only
+
+The following are explicitly not part of v1:
+
+- Raw IP-address members
+- HTTP and HTTPS listeners
+- Terminated TLS
+- L7 routing or policies
+- Weighted or backup members
+- Session persistence
+- Alternate monitor IP or port
+- Non-L4 health check types
+- Additional Amphora timeout knobs beyond `idleTimeoutSeconds`
+- IPv6 VIPs or members
+- Mixed IPv4 and IPv6 members
+- Additional VIPs
+- Listener connection limits
+- Raw IP members
+
+## API Surface
+
+Add the following Region v2 endpoints:
+
+- `GET /api/v2/loadbalancers`
+- `POST /api/v2/loadbalancers`
+- `GET /api/v2/loadbalancers/{loadBalancerID}`
+- `PUT /api/v2/loadbalancers/{loadBalancerID}`
+- `DELETE /api/v2/loadbalancers/{loadBalancerID}`
+
+All write operations are asynchronous and return `202 Accepted`. Callers must read `status.conditions` to determine whether provisioning has completed.
+
+List filters follow existing Region v2 conventions:
+
+- `organizationID`
+- `projectID`
+- `regionID`
+- `networkID`
+- `tag`
+
+RBAC adds the new scope:
+
+- `region:loadbalancers:v2`
+
+Provider capability discovery adds:
+
+- `region.features.loadBalancers: bool`
+
+## Public Types
+
+Add the following public OpenAPI types and generated clients:
+
+- `LoadBalancerV2Create`
+- `LoadBalancerV2CreateSpec`
+- `LoadBalancerV2Update`
+- `LoadBalancerV2Spec`
+- `LoadBalancerV2Read`
+- `LoadBalancersV2Read`
+- `LoadBalancerV2Status`
+- `LoadBalancerListenerV2`
+- `LoadBalancerPoolV2`
+- `LoadBalancerMemberV2`
+- `LoadBalancerHealthCheckV2`
+
+Add the list query parameter type:
+
+- `GetApiV2LoadbalancersParams`
+
+Add the path parameter:
+
+- `loadBalancerIDParameter`
+
+## Resource Model
+
+The standard Region v2 envelope applies. This section defines the `spec` and `status` payloads specific to load balancers.
+
+### Create Spec
+
+`LoadBalancerV2CreateSpec` contains:
+
+| Field | Required | Description |
+|---|---|---|
+| `organizationId` | yes | Owning organization. Immutable after create. |
+| `projectId` | yes | Owning project. Immutable after create. |
+| `regionId` | yes | Target region. Immutable after create. |
+| `networkId` | yes | Tenant network used for the VIP subnet and backend member resolution. Immutable after create. |
+| `publicIP` | no | When `true`, request a public IPv4 address for the VIP. |
+| `listeners` | yes | Listener definitions. |
+
+### Mutable Spec
+
+`LoadBalancerV2Spec` contains:
+
+| Field | Required | Description |
+|---|---|---|
+| `publicIP` | no | Mutable after create. |
+| `listeners` | yes | Listener and pool configuration. |
+
+### Status
+
+`LoadBalancerV2Status` contains:
+
+| Field | Required | Description |
+|---|---|---|
+| `regionId` | yes | Region the load balancer is running in. |
+| `networkId` | yes | Tenant network backing the VIP and member reachability. |
+| `vipAddress` | yes | VIP address allocated for the load balancer. |
+| `publicIP` | no | Public IPv4 address attached to the VIP when enabled. |
+| `conditions` | yes | Standard platform `status.conditions`. |
+
+Rules:
+
+- `organizationId`, `projectId`, `regionId`, and `networkId` are immutable after create.
+- `publicIP` is mutable.
+- `networkId` is the required backend network for all referenced compute instances.
+- The public status surface is provider-agnostic. Provider IDs, per-listener operating status, per-member health, statistics, the algorithm, the status tree, and driver names are not exposed in v1.
+
+## Listener Schema
+
+Each listener is represented by `LoadBalancerListenerV2`:
+
+| Field | Required | Description |
+|---|---|---|
+| `name` | yes | Listener name, unique within the load balancer. |
+| `protocol` | yes | `tcp` or `udp`. |
+| `port` | yes | Frontend port number. |
+| `allowedCidrs` | no | IPv4 CIDRs allowed to reach this listener. |
+| `idleTimeoutSeconds` | no | TCP-only idle timeout override. |
+| `pool` | yes | Exactly one backend pool for this listener. |
+
+Listener rules:
+
+- `name` must be unique within the load balancer.
+- `(protocol, port)` must be unique within the load balancer.
+- `allowedCidrs` uses OR semantics.
+- Omitted or empty `allowedCidrs` means unrestricted ingress for that listener.
+- Every `allowedCidrs` entry must be a valid IPv4 CIDR.
+- `idleTimeoutSeconds` is valid only for `tcp`.
+- Omitted `idleTimeoutSeconds` means provider default.
+
+## Pool Schema
+
+Each listener owns exactly one `LoadBalancerPoolV2`:
+
+| Field | Required | Description |
+|---|---|---|
+| `proxyProtocolV2` | no | TCP-only backend PROXY protocol version 2 toggle. |
+| `members` | yes | Backend members. |
+| `healthCheck` | no | Optional transport-level health check. |
+
+Pool rules:
+
+- Exactly one pool exists per listener.
+- `proxyProtocolV2` is valid only for `tcp` listeners.
+- `proxyProtocolV2=true` means the backend connection is wrapped in PROXY protocol version 2.
+- There is no public `algorithm` field.
+- The implementation fixes the hidden algorithm to `ROUND_ROBIN`.
+
+## Member Schema
+
+Members are limited to `uni-compute` instances in v1.
+
+Each `LoadBalancerMemberV2` contains:
+
+| Field | Required | Description |
+|---|---|---|
+| `instanceId` | yes | Referenced compute instance. |
+| `port` | yes | Backend port used for this member. |
+
+Member rules:
+
+- `instanceId` is required.
+- `port` is required.
+- Duplicate `instanceId` values in one pool are rejected.
+- Duplicate resolved `(privateIP, port)` backends are rejected once instance IPs are known.
+- Raw IP-address members are unsupported in v1.
+
+## Health Check Schema
+
+`LoadBalancerHealthCheckV2` is optional and contains:
+
+| Field | Required | Description |
+|---|---|---|
+| `intervalSeconds` | no | Probe interval. Default `10` when enabled. |
+| `timeoutSeconds` | no | Per-probe timeout. Default `5` when enabled. |
+| `healthyThreshold` | no | Successes required to mark healthy. Default `2` when enabled. |
+| `unhealthyThreshold` | no | Failures required to mark unhealthy. Default `2` when enabled. |
+
+Health-check rules:
+
+- Omitted or `null` means disabled.
+- `{}` means enabled with defaults.
+- There is no `enabled` field.
+- There is no `protocol` field.
+- There is no `port` field.
+- There are no HTTP, HTTPS, TLS, or other L7-specific health-check fields.
+- `timeoutSeconds` must be less than `intervalSeconds` when a health check is present.
+- Health checks always target the member's configured backend port using transport semantics derived from the listener protocol and pool settings.
+
+## Validation and Error Semantics
+
+The request body is first validated against the OpenAPI schema. Schema or field-format failures should return `400 invalid_request`. Cross-field or cross-resource semantic failures should return `422 unprocessable_content`.
+
+Create and update validation must enforce all of the following:
+
+- `organizationId`, `projectId`, `regionId`, and `networkId` remain immutable after create.
+- Every `instanceId` resolves through the Compute v2 API.
+- Every referenced compute instance belongs to the same organization, project, region, and network as the load balancer.
+- Referenced compute instances may exist before private IP assignment. In that case the load balancer remains provisioning until the address resolves.
+- `proxyProtocolV2=true` is rejected for `udp`.
+- `idleTimeoutSeconds` is rejected for `udp`.
+- `timeoutSeconds` must be less than `intervalSeconds` when a health check is present.
+- Duplicate listener names are rejected.
+- Duplicate `(protocol, port)` listeners are rejected.
+- Duplicate `instanceId` members are rejected.
+- Duplicate resolved `(privateIP, port)` backends are rejected.
+
+Preferred response behavior:
+
+| Condition | Preferred response |
+|---|---|
+| Invalid IPv4 CIDR syntax in `allowedCidrs` | `400 invalid_request` |
+| Unsupported field combinations such as `proxyProtocolV2=true` on `udp` or `idleTimeoutSeconds` on `udp` | `422 unprocessable_content` |
+| `timeoutSeconds >= intervalSeconds` | `422 unprocessable_content` |
+| Duplicate listener names, duplicate `(protocol, port)` listeners, duplicate `instanceId` members, or duplicate resolved `(privateIP, port)` backends | `422 unprocessable_content` |
+| Supplied `instanceId` cannot be resolved to a usable compute instance in the same scope | `422 unprocessable_content` |
+| Resolved compute instance is on a different network | `422 unprocessable_content` |
+
+The validation error for an unusable `instanceId` must be generic. It must not disclose whether the supplied ID was nonexistent, unreadable, or merely outside the caller's scope.
+
+## Cross-Service Semantics
+
+The Region load balancer controller maintains permanent references to:
+
+- The consumed Region `Network`
+- Every referenced `uni-compute` compute instance
+
+The resource graph semantics are:
+
+- Network deletion is blocked while a load balancer exists.
+- Referenced compute-instance deletion is blocked while it remains a member.
+- References are reconciled on every pass so removed members release references.
+- Region subscribes to compute-instance lifecycle events through the platform event mechanism.
+- On a compute-instance event, Region re-reads the compute instance through the Compute API and reconciles the affected load balancer.
+- If a referenced instance's private IP changes, backend members are updated in place.
+- If a referenced instance temporarily has no private IP, the load balancer remains present but not ready until the address is available or the member is removed.
+
+## Defaults and Derived Behavior
+
+The initial public behavior is:
+
+- `publicIP` is top-level on the load balancer spec.
+- `allowedCidrs` is listener-scoped.
+- `proxyProtocolV2` is v2-only and TCP-only.
+- `healthCheck` object presence means enabled.
+- Health-check omission means disabled.
+- `healthCheck: {}` means enabled with defaults.
+- Omitted `idleTimeoutSeconds` uses provider defaults.
+- The implementation is IPv4-only.
+
+Provider-specific protocol, health-monitor, timeout, and persistence mapping is defined in [OpenStack Load Balancers](../providers/openstack/load-balancers.md).

--- a/specifications/region/load-balancers.md
+++ b/specifications/region/load-balancers.md
@@ -8,7 +8,7 @@ The standard Region v2 resource envelope and the platform-wide rules in [SPECIFI
 
 | Version | Date | Notes |
 |---|---|---|
-| v0.3 | 2026-04-11 | Members specified by IP address instead of compute-instance reference; Compute-Member Lifecycle cross-service dependency removed |
+| v0.3 | 2026-04-11 | Members specified by IP address instead of compute-instance reference; Compute-Member Lifecycle cross-service dependency removed; VIP stability and `Available` precondition guarantees added |
 | v0.2 | 2026-04-10 | Review update: empty member sets, dependency-triggered deletion, stale-member tolerance, and clarified validation/status semantics |
 | v0.1 | 2026-04-10 | Initial draft |
 
@@ -142,7 +142,9 @@ Rules:
 - `publicIP` is mutable.
 - `networkId` is the required backend network. All member addresses must be reachable on this network.
 - `spec.publicIP` requests a public VIP address and `status.publicIP` reports the allocated public IPv4. This intentionally matches the existing instance API naming convention.
+- `status.vipAddress` is stable for the lifetime of the load balancer. Once allocated, the VIP does not change.
 - There is no `vipAddress` request field in create or update. Callers cannot request a specific VIP or private address in v1, so Kubernetes `spec.loadBalancerIP`-style workflows are unsupported.
+- `Available=True` must not be reported until `status.vipAddress` is populated.
 - The public status surface is provider-agnostic. Provider IDs, per-listener operating status, per-member health, statistics, the algorithm, the status tree, and driver names are not exposed in v1.
 
 ## Listener Schema

--- a/specifications/region/load-balancers.md
+++ b/specifications/region/load-balancers.md
@@ -8,6 +8,7 @@ The standard Region v2 resource envelope and the platform-wide rules in [SPECIFI
 
 | Version | Date | Notes |
 |---|---|---|
+| v0.2 | 2026-04-15 | Align network deletion semantics with owner-based foreground cascade while keeping network status propagation. |
 | v0.1 | 2026-04-13 | Initial version |
 
 ## Initial Scope
@@ -307,21 +308,26 @@ Per [SPECIFICATION.md §7.6](../../SPECIFICATION.md), v1 requires quota enforcem
 
 ### Edge Declarations
 
-Per [SPECIFICATION.md §5.10](../../SPECIFICATION.md), the LoadBalancer resource type declares the following edge:
+Per [SPECIFICATION.md §5.8](../../SPECIFICATION.md) and [§5.10](../../SPECIFICATION.md), the LoadBalancer resource type declares separate lifecycle and status relationships for the same resource pair because deletion ownership and status observation point in opposite directions:
 
-| Edge | Type | Properties |
-|---|---|---|
-| LoadBalancer → Network | Dependency | Reverse Deletion Propagation (triggering) + Status Propagation Upward + Co-location Required |
+| Relationship | Properties |
+|---|---|
+| Network → LoadBalancer | Forward Deletion Propagation via Kubernetes owner reference with blocking owner deletion / foreground cascading semantics |
+| LoadBalancer → Network | Status Propagation Upward + Co-location Required |
 
-This is an intra-service edge (both resources are owned by the Region service). No blocking reference is placed on the Network per the Dependency edge contract ([SPECIFICATION.md §5.7](../../SPECIFICATION.md)).
+Both relationships are intra-service (the Region service owns both resource types). No long-lived reference API hold is placed on the Network during steady-state load-balancer lifetime.
 
-### Network Dependency
+### Network Ownership and Status Observation
 
-- `networkId` establishes a dependency edge from the load balancer to the Region `Network`.
-- If the referenced network enters `DELETING`, the controller must initiate deletion of the dependent load balancer. The network is not blocked by the load balancer.
-- The controller registers a Kubernetes watch on the Network resource type (intra-service edge per [SPECIFICATION.md §8.6](../../SPECIFICATION.md)) as the fast-path trigger for network deletion and status changes.
-- Every load balancer reconcile must also `Get` the referenced Network directly. If the Network is missing or already has a deletion timestamp, the controller must initiate load balancer deletion even if the watch event was missed while the controller was down.
-- When the Network's status changes, the controller re-derives the load balancer's status from the aggregate state of connected targets (status propagation upward per [SPECIFICATION.md §5.8](../../SPECIFICATION.md)). If the Network becomes unavailable, the load balancer reflects this in its own conditions.
+- `networkId` is immutable after create.
+- On create, the handler validates the referenced `Network` and creates the backing `LoadBalancer` resource with that `Network` as its Kubernetes owner. Because `networkId` cannot change later, this owner relationship is fixed for the lifetime of the load balancer.
+- The owner reference uses blocking owner deletion / foreground cascading semantics. When the `Network` is deleted, Kubernetes tombstones the owned `LoadBalancer` as part of the same intra-service delete flow.
+- Standalone `DELETE` of a load balancer is unchanged.
+- During a network delete, the load balancer controller does not independently synthesize deletion from the `Network` deletion timestamp. It reconciles the already-deleting `LoadBalancer`, performs normal provider deprovisioning, releases quota state, and removes its finalizer.
+- The controller registers a Kubernetes watch on the `Network` resource type and directly `Get`s the referenced `Network` during reconcile for status propagation only. These reads are not used to synthesize load-balancer deletion from a network tombstone.
+- When the `Network` status changes, the controller re-derives the load balancer's status from the aggregate state of connected targets (status propagation upward per [SPECIFICATION.md §5.8](../../SPECIFICATION.md)).
+- If the `LoadBalancer` already has a deletion timestamp, a missing or deleting `Network` is expected during owner-driven cascade and must not be treated as a separate dependency-triggered delete path.
+- If the `LoadBalancer` is not deleting and the observed `Network` is unavailable, the load balancer reflects this in `Available=False`.
 
 ### Member Address Semantics
 
@@ -339,7 +345,7 @@ This is an intra-service edge (both resources are owned by the Region service). 
 
 The standard Region v2 handler layer responsibilities ([SPECIFICATION.md §7.2](../../SPECIFICATION.md)) apply. Load-balancer-specific notes:
 
-- **Create**: the handler derives labels and annotations via `conversion.NewObjectMetadata`. Labels and annotations are never accepted from the request body. The handler uses a saga with soft reservation steps for `1` `loadbalancers` quota unit and, when `spec.publicIP=true`, `1` `publicips` quota unit per [SPECIFICATION.md §7.5, §7.6](../../SPECIFICATION.md), then creates the `LoadBalancer` CRD as the terminal write. If `spec.vipAddress` is present, the handler persists it as a distinct immutable internal field (for example `requestedVipAddress`) on the backing resource so reconcile can replay the same provider request idempotently across retries and restarts. If either quota is exhausted, it returns `403 forbidden`.
+- **Create**: the handler validates the referenced `Network`, derives labels and annotations via `conversion.NewObjectMetadata`, and never accepts labels or annotations from the request body. It uses a saga with soft reservation steps for `1` `loadbalancers` quota unit and, when `spec.publicIP=true`, `1` `publicips` quota unit per [SPECIFICATION.md §7.5, §7.6](../../SPECIFICATION.md), then creates the `LoadBalancer` CRD as the terminal write with the referenced `Network` set as Kubernetes owner using blocking owner deletion / foreground cascading semantics. If `spec.vipAddress` is present, the handler persists it as a distinct immutable internal field (for example `requestedVipAddress`) on the backing resource so reconcile can replay the same provider request idempotently across retries and restarts. If either quota is exhausted, it returns `403 forbidden`.
 - **Update**: the handler reads the current resource, re-derives labels and annotations, and patches with optimistic locking via `MergeFromWithOptimisticLock`. A concurrent modification returns `409 conflict`. `vipAddress` is intentionally absent from `LoadBalancerV2Spec`; any `PUT` body containing it fails schema validation with `400 invalid_request`. If `publicIP` toggles from `false` to `true`, the handler reserves `1` `publicips` unit before patching the CRD and returns `403 forbidden` if exhausted; the reservation is released as compensation if the CRD patch fails. If `publicIP` toggles from `true` to `false`, the `publicips` unit is released by the controller during floating IP deprovisioning.
 - **Delete**: the handler verifies `DeletionTimestamp` is nil before issuing the delete. If already set, it returns `202` idempotently.
 
@@ -349,7 +355,7 @@ All POST, PUT, and DELETE operations emit audit log entries per [SPECIFICATION.m
 
 ### Finalizer
 
-The controller adds its finalizer to the `LoadBalancer` resource before performing any provisioning work. On deletion, the controller detects the deletion timestamp, retries silently while owned children or references exist, runs full deprovisioning (including all provider resources), releases any committed quota allocation or surviving reservation, and removes the finalizer only after deprovisioning completes per [SPECIFICATION.md §8.5](../../SPECIFICATION.md).
+The controller adds its finalizer to the `LoadBalancer` resource before performing any provisioning work. On deletion, whether initiated directly or via owner-driven `Network` cascade, the controller detects the load balancer deletion timestamp, retries silently while owned children or references exist, runs full deprovisioning (including all provider resources), releases any committed quota allocation or surviving reservation, and removes the finalizer only after deprovisioning completes per [SPECIFICATION.md §8.5](../../SPECIFICATION.md).
 
 ### Deadlock Detection
 

--- a/specifications/region/load-balancers.md
+++ b/specifications/region/load-balancers.md
@@ -283,14 +283,12 @@ All error responses follow the standard platform error body format (`error`, `er
 
 ## Quota Semantics
 
-Per [SPECIFICATION.md §7.6](../../SPECIFICATION.md), v1 requires quota enforcement for load balancer count.
+Per [SPECIFICATION.md §7.6](../../SPECIFICATION.md), v1 requires quota enforcement for both load balancer count and public IP allocation. The quota kind for public IPs is `publicips`, which is a shared quota defined in `uni-identity` (default: 5) and consumed by all services that allocate public IPs (compute instances, load balancers, etc.).
 
-- Create reserves `1` load balancer quota unit keyed by the load balancer resource UUID before returning `202 Accepted`. If quota is exhausted, the handler returns `403 forbidden`.
-- Successful provisioning promotes that reservation to a committed allocation.
-- Update does not change quota consumption. This spec does not quota-track `publicIP`, so toggling it does not consume or release load balancer quota.
-- Delete releases the committed allocation, or any still-active reservation, before the controller removes its finalizer.
-
-Shared floating-IP/public-IP quota is a cross-resource concern spanning instances and load balancers. It must be specified once at the platform level for all consumers and is intentionally not defined in this resource-specific v1 document.
+- **Create**: the saga reserves `1` `loadbalancers` quota unit keyed by the load balancer resource UUID. If `spec.publicIP=true`, the saga also reserves `1` `publicips` unit keyed by the same UUID. If either quota is exhausted, the handler returns `403 forbidden`.
+- Successful provisioning promotes both reservations to committed allocations.
+- **Update**: if `publicIP` changes from `false` to `true`, the handler updates the allocation to add `1` `publicips` unit (quota check applies; `403 forbidden` if exhausted). If `publicIP` changes from `true` to `false`, the handler updates the allocation to remove the `publicips` unit. Changes to `publicIP` do not affect the `loadbalancers` quota.
+- **Delete**: releasing the committed allocation covers both `loadbalancers` and `publicips` (whichever was committed) before the controller removes its finalizer.
 
 ## Resource Graph
 
@@ -328,8 +326,8 @@ This is an intra-service edge (both resources are owned by the Region service). 
 
 The standard Region v2 handler layer responsibilities ([SPECIFICATION.md §7.2](../../SPECIFICATION.md)) apply. Load-balancer-specific notes:
 
-- **Create**: the handler derives labels and annotations via `conversion.NewObjectMetadata`. Labels and annotations are never accepted from the request body. The handler uses a saga with a soft reservation step for `1` load balancer quota unit per [SPECIFICATION.md §7.5, §7.6](../../SPECIFICATION.md), then creates the `LoadBalancer` CRD as the terminal write. If quota is exhausted, it returns `403 forbidden`.
-- **Update**: the handler reads the current resource, re-derives labels and annotations, and patches with optimistic locking via `MergeFromWithOptimisticLock`. A concurrent modification returns `409 conflict`. Updates do not change quota consumption because only load balancer count is quota-tracked here.
+- **Create**: the handler derives labels and annotations via `conversion.NewObjectMetadata`. Labels and annotations are never accepted from the request body. The handler uses a saga with soft reservation steps for `1` `loadbalancers` quota unit and, when `spec.publicIP=true`, `1` `publicips` quota unit per [SPECIFICATION.md §7.5, §7.6](../../SPECIFICATION.md), then creates the `LoadBalancer` CRD as the terminal write. If either quota is exhausted, it returns `403 forbidden`.
+- **Update**: the handler reads the current resource, re-derives labels and annotations, and patches with optimistic locking via `MergeFromWithOptimisticLock`. A concurrent modification returns `409 conflict`. If `publicIP` toggles from `false` to `true`, the handler checks `publicips` quota and returns `403 forbidden` if exhausted, then updates the allocation to add the `publicips` unit. If `publicIP` toggles from `true` to `false`, the handler updates the allocation to remove the `publicips` unit.
 - **Delete**: the handler verifies `DeletionTimestamp` is nil before issuing the delete. If already set, it returns `202` idempotently.
 
 All POST, PUT, and DELETE operations emit audit log entries per [SPECIFICATION.md §9.2](../../SPECIFICATION.md).

--- a/specifications/region/load-balancers.md
+++ b/specifications/region/load-balancers.md
@@ -135,7 +135,7 @@ The standard Region v2 envelope applies. This section defines the `spec` and `st
 |---|---|---|
 | `regionId` | yes | Region the load balancer is running in. |
 | `networkId` | yes | Tenant network backing the VIP and member reachability. |
-| `vipAddress` | yes | VIP address allocated for the load balancer. |
+| `vipAddress` | no | VIP address allocated for the load balancer. |
 | `publicIP` | no | Public IPv4 address attached to the VIP when enabled. |
 | `conditions` | yes | Standard platform `status.conditions`. |
 


### PR DESCRIPTION
Add load balancer specifications for the region v2 public API and the OpenStack Octavia provider mapping.

- Region load balancer spec: Layer 4 LB abstraction with TCP/UDP listeners, IP-based members, health monitors
- OpenStack provider spec: Octavia Amphora mapping with floating IP VIP, status reconciliation, finalizer lifecycle
- Updated README to reference the new specs